### PR TITLE
Use Hack as monospace font with good unicode coverage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM pandoc/latex:2.16.2
 
+RUN apk add --no-cache ttf-hack
+
 # Install additional LaTeX packages
 RUN tlmgr update --self && tlmgr install \
   algorithmicx \

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -234,6 +234,9 @@ $endif$
 \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
 }{}
 
+% Use Hack https://sourcefoundry.org/hack/
+\setmonofont{Hack}
+
 \usepackage{hyperref}
 $if(colorlinks)$
 \PassOptionsToPackage{usenames,dvipsnames}{color} % color is loaded by hyperref


### PR DESCRIPTION
This allows unicode in code blocks, as is especially popular in Julia
submissions (https://github.com/openjournals/joss/issues/963).

Cc: https://github.com/openjournals/whedon/pull/105