### PR TITLE
PDF/A-3b support

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -467,7 +467,7 @@ $endif$
     \setlength\itemsep{0em}
     \item \href{$software_review_url$}{\color{linky}{Review}} \ExternalLink
     \item \href{$software_repository_url$}{\color{linky}{Repository}} \ExternalLink
-    \item \href{https://dx.doi.org/$archive_doi$}{\color{linky}{Archive}} \ExternalLink
+    \item \href{https://doi.org/$archive_doi$}{\color{linky}{Archive}} \ExternalLink
   \end{itemize}
 
   \vspace{2mm}

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -1,15 +1,66 @@
 \documentclass[10pt,a4paper,onecolumn]{article}
 \usepackage{marginnote}
 \usepackage{graphicx}
-\usepackage{xcolor}
+\usepackage[rgb]{xcolor}
 \usepackage{authblk,etoolbox}
 \usepackage{titlesec}
 \usepackage{calc}
 \usepackage{tikz}
-\usepackage{hyperref}
-\hypersetup{colorlinks,breaklinks=true,
-            urlcolor=[rgb]{0.0, 0.5, 1.0},
-            linkcolor=[rgb]{0.0, 0.5, 1.0}}
+\usepackage[pdfa]{hyperref}
+\usepackage{hyperxmp}
+\usepackage{embedfile}
+\hypersetup{%
+    unicode=true,
+    pdfapart=3,
+    pdfaconformance=B,
+    $if(title-meta)$
+    pdftitle={$title-meta$},
+    $endif$
+    $if(author-meta)$
+    pdfauthor={$author-meta$},
+    $endif$
+    $if(keywords)$
+    pdfkeywords={$for(keywords)$$keywords$$sep$; $endfor$},
+    $endif$
+    pdfpublication={$journal_name$},
+    pdfpublisher={Open Journals},
+    pdfissn={$journal_issn$},
+    pdfpubtype={journal},
+    pdfvolumenum={$volume$},
+    pdfissuenum={$issue$},
+    $if(formatted_doi)$
+    pdfdoi={$formatted_doi$},
+    $endif$
+    $if(author-meta)$
+    pdfcopyright={Copyright (c) $year$, $author-meta$},
+    $endif$
+    pdflicenseurl={http://creativecommons.org/licenses/by/4.0/},
+    $if(colorlinks)$
+    colorlinks=true,
+    linkcolor=$if(linkcolor)$$linkcolor$$else$Maroon$endif$,
+    citecolor=$if(citecolor)$$citecolor$$else$Blue$endif$,
+    urlcolor=$if(urlcolor)$$urlcolor$$else$Blue$endif$,
+    $else$
+    pdfborder={0 0 0},
+    $endif$
+    breaklinks=true
+}
+% https://tex.stackexchange.com/a/535849
+\embedfile[afrelationship={/Source},ucfilespec={\jobname.tex},mimetype={application/x-tex}]{\jobname.tex}
+% Create an OutputIntent in order to correctly specify colours
+\immediate\pdfobj stream attr{/N 3} file{sRGB.icc}
+\pdfcatalog{%
+  /OutputIntents [
+    <<
+      /Type /OutputIntent
+      /S /GTS_PDFA1
+      /DestOutputProfile \the\pdflastobj\space 0 R
+      /OutputConditionIdentifier (sRGB)
+      /Info (sRGB)
+    >>
+  ]
+}
+\pdfvariable omitcidset=1
 \usepackage{caption}
 \usepackage{tcolorbox}
 \usepackage{amssymb,amsmath}
@@ -237,29 +288,9 @@ $endif$
 % Use Hack https://sourcefoundry.org/hack/
 \setmonofont{Hack}
 
-\usepackage{hyperref}
 $if(colorlinks)$
 \PassOptionsToPackage{usenames,dvipsnames}{color} % color is loaded by hyperref
 $endif$
-\hypersetup{unicode=true,
-$if(title-meta)$
-            pdftitle={$title-meta$},
-$endif$
-$if(author-meta)$
-            pdfauthor={$author-meta$},
-$endif$
-$if(keywords)$
-            pdfkeywords={$for(keywords)$$keywords$$sep$; $endfor$},
-$endif$
-$if(colorlinks)$
-            colorlinks=true,
-            linkcolor=$if(linkcolor)$$linkcolor$$else$Maroon$endif$,
-            citecolor=$if(citecolor)$$citecolor$$else$Blue$endif$,
-            urlcolor=$if(urlcolor)$$urlcolor$$else$Blue$endif$,
-$else$
-            pdfborder={0 0 0},
-$endif$
-            breaklinks=true}
 \urlstyle{same}  % don't use monospace font for urls
 $if(lang)$
 \ifLuaTeX


### PR DESCRIPTION
The resulting papers verify as PDF/A-3b with `verapdf`, but there are some issues left before we can merge:

- [x] I needed to switch to lualatex for this, which would be fine except it isn't working with `babel` (works in simple tests, however). Perhaps someone (@tarleb?) knows how to fix this. `pdflang` will be set automatically once `babel` works.
- [x] For some reason, `author-meta` is not being provided by Pandoc, thus `hyperxmp` is falling bock to the `\author` block, which mangles the author list.
- [x] There are a number of additional fields that can be set. See the [hyperxmp docs](https://mirror.las.iastate.edu/tex-archive/macros/latex/contrib/hyperxmp/hyperxmp.pdf).
- [ ] Inclusion of some images will result in lack of compliance. I haven't figured out why. Some included PDF (non-PDF/A) work but some don't. It appears that PDF created by `rsvg-convert` (i.e., cairo) prevent verification, though PDF created by TeX or ImageMagick (ugly rasters) are fine. Unfortunately, the issue with Cairo also means that `![](image.svg)` results in a PDF/A that fails to verify. This might need to be fixed upstream in librsvg/cairo.

<details>

```xml
      <validationReport profileName="PDF/A-3B validation profile" statement="PDF file is not compliant with Validation Profile requirements." isCompliant="false">
        <details passedRules="123" failedRules="1" passedChecks="112968" failedChecks="4">
          <rule specification="ISO 19005-3:2012" clause="6.2.8" testNumber="3" status="failed" passedChecks="0" failedChecks="4">
            <description>If an Image dictionary contains the Interpolate key, its value shall be false.
            For an inline image, the I key shall have a value of false.</description>
            <object>PDXImage</object>
            <test>Interpolate == false</test>
            <check status="failed">
              <context>root/document[0]/pages[1](114 0 obj PDPage)/contentStream[0](115 0 obj PDContentStream)/operators[507]/xObject[0]/contentStream[0](110 0 obj PDContentStream)/operators[
12]/xObject[0]/contentStream[0](122 0 obj PDContentStream)/operators[3]/xObject[0]/contentStream[0](135 0 obj PDContentStream)/operators[2]/xObject[0]/contentStream[0](143 0 obj PDContentStre
am)/operators[9]/xObject[0](163 0 obj PDXImage)</context>
            </check>
            <check status="failed">
              <context>root/document[0]/pages[1](114 0 obj PDPage)/contentStream[0](115 0 obj PDContentStream)/operators[507]/xObject[0]/contentStream[0](110 0 obj PDContentStream)/operators[
17]/xObject[0]/contentStream[0](123 0 obj PDContentStream)/operators[3]/xObject[0]/contentStream[0](137 0 obj PDContentStream)/operators[2]/xObject[0]/contentStream[0](145 0 obj PDContentStre
am)/operators[9]/xObject[0](165 0 obj PDXImage)</context>
            </check>
            <check status="failed">
              <context>root/document[0]/pages[1](114 0 obj PDPage)/contentStream[0](115 0 obj PDContentStream)/operators[507]/xObject[0]/contentStream[0](110 0 obj PDContentStream)/operators[
22]/xObject[0]/contentStream[0](124 0 obj PDContentStream)/operators[3]/xObject[0]/contentStream[0](139 0 obj PDContentStream)/operators[2]/xObject[0]/contentStream[0](147 0 obj PDContentStre
am)/operators[9]/xObject[0](167 0 obj PDXImage)</context>
            </check>
            <check status="failed">
              <context>root/document[0]/pages[1](114 0 obj PDPage)/contentStream[0](115 0 obj PDContentStream)/operators[507]/xObject[0]/contentStream[0](110 0 obj PDContentStream)/operators[
27]/xObject[0]/contentStream[0](125 0 obj PDContentStream)/operators[3]/xObject[0]/contentStream[0](141 0 obj PDContentStream)/operators[2]/xObject[0]/contentStream[0](149 0 obj PDContentStre
am)/operators[9]/xObject[0](169 0 obj PDXImage)</context>
            </check>
          </rule>
        </details>
      </validationReport>
```
</details>

Cc: https://github.com/openjournals/joss/issues/901 https://github.com/openjournals/joss/issues/1030