### PR TITLE
Change JOSS DOI url in the Crossref default template

### DIFF
--- a/data/templates/default.crossref
+++ b/data/templates/default.crossref
@@ -98,10 +98,10 @@ $endfor$
         </rel:program>
         <doi_data>
           <doi>$article.doi$</doi>
-          <resource>https://joss.theoj.org/joss-papers/$article.doi$</resource>
+          <resource>https://joss.theoj.org/papers/$article.doi$</resource>
           <collection property="text-mining">
             <item>
-              <resource mime_type="application/pdf">https://joss.theoj.org/joss-papers/${article.doi}.pdf</resource>
+              <resource mime_type="application/pdf">https://joss.theoj.org/papers/${article.doi}.pdf</resource>
             </item>
           </collection>
         </doi_data>

--- a/data/templates/default.crossref
+++ b/data/templates/default.crossref
@@ -98,10 +98,10 @@ $endfor$
         </rel:program>
         <doi_data>
           <doi>$article.doi$</doi>
-          <resource>https://joss.theoj.com/joss-papers/$article.doi$</resource>
+          <resource>https://joss.theoj.org/joss-papers/$article.doi$</resource>
           <collection property="text-mining">
             <item>
-              <resource mime_type="application/pdf">https://joss.theoj.com/joss-papers/${article.doi}.pdf</resource>
+              <resource mime_type="application/pdf">https://joss.theoj.org/joss-papers/${article.doi}.pdf</resource>
             </item>
           </collection>
         </doi_data>


### PR DESCRIPTION
The current URL is incorrect.
before: `https://joss.theoj.com/joss-papers/`
after: `https://joss.theoj.org/papers/`