### PR TITLE
LaTeX template: remove outdated handling of URLs

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -407,10 +407,10 @@ $for(affiliations)$
 \affil[$affiliations.index$]{$affiliations.name$}
 $endfor$
 $if(article.author-notes.corresp)$
-\affil[$article.author-notes.corresp$ $$\mathparagraph$$]{Corresponding author}
+\affil[$$\mathparagraph$$]{Corresponding author}
 $endif$
 $if(article.has-equal-contributors)$
-\affil[*]{$if(messgae.equal-contrib)$$message.equal-contrib$$else$These authors contributed equally.$endif$}
+\affil[*]{$if(message.equal-contrib)$$message.equal-contrib$$else$These authors contributed equally.$endif$}
 $endif$
 \date{\vspace{-2.5ex}}
 

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -85,33 +85,6 @@ $endif$
   \allowbreak
   \else\penalty6000\hspace{0pt plus 0.02em}\fi}
 
-
-% --- Pandoc does not distinguish between links like [foo](bar) and
-% --- [foo](foo) -- a simplistic Markdown model.  However, this is
-% --- wrong:  in links like [foo](foo) the text is the url, and must
-% --- be split correspondingly.
-% --- Here we detect links \href{foo}{foo}, and also links starting
-% --- with https://doi.org, and use path-like splitting (but not
-% --- escaping!) with these links.
-% --- Another vile thing pandoc does is the different escaping of
-% --- foo and bar.  This may confound our detection.
-% --- This problem we do not try to solve at present, with the exception
-% --- of doi-like urls, which we detect correctly.
-
-
-\makeatletter
-\let\href@Orig=\href
-\def\href@Urllike#1#2{\href@Orig{#1}{\begingroup
-    \def\Url@String{#2}\Url@FormatString
-    \endgroup}}
-\def\href@Notdoi#1#2{\def\tempa{#1}\def\tempb{#2}%
-  \ifx\tempa\tempb\relax\href@Urllike{#1}{#2}\else
-  \href@Orig{#1}{#2}\fi}
-\def\href#1#2{%
-  \IfBeginWith{#1}{https://doi.org}%
-  {\href@Urllike{#1}{#2}}{\href@Notdoi{#1}{#2}}}
-\makeatother
-
 $if(csl-refs)$
 \newlength{\cslhangindent}
 \setlength{\cslhangindent}{1.5em}


### PR DESCRIPTION
The template contained code to modify the behavior of `\href`, ensuring
special handling of links that have the URL as link text. These patches
are no longer necessary: Pandoc handles links like `[foo](foo)`
specially and writes them as `\url{foo}`.