### PR TITLE
Support generation of LaTeX files without JOSS styling

### DIFF
--- a/data/defaults/arxiv.yaml
+++ b/data/defaults/arxiv.yaml
@@ -1,0 +1,9 @@
+to: latex
+extract-media: media
+variables:
+  arxiv: true
+  # styling options
+  colorlinks: true
+  linkcolor: '[rgb]{0.0, 0.5, 1.0}'
+  urlcolor: '[rgb]{0.0, 0.5, 1.0}'
+

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -22,6 +22,8 @@ $if(keywords)$
     pdfkeywords={$for(keywords)$$keywords$$sep$; $endfor$},
 $endif$
     pdfpublication={$journal.title$},
+$if(arxiv)$
+$else$
     pdfpublisher={Open Journals},
     pdfissn={$journal.issn$},
     pdfpubtype={journal},
@@ -30,10 +32,11 @@ $endif$
 $if(article.doi)$
     pdfdoi={$article.doi$},
 $endif$
+    pdflicenseurl={http://creativecommons.org/licenses/by/4.0/},
+$endif$
 $if(author-meta)$
     pdfcopyright={Copyright (c) $year$, $author-meta$},
 $endif$
-    pdflicenseurl={http://creativecommons.org/licenses/by/4.0/},
 $if(colorlinks)$
     colorlinks=true,
     linkcolor=$if(linkcolor)$$linkcolor$$else$Maroon$endif$,
@@ -133,6 +136,8 @@ $endif$
 \pagestyle{fancy}
 \fancyhf{}
 %\renewcommand{\headrulewidth}{0.50pt}
+$if(arxiv)$
+$else$
 \renewcommand{\headrulewidth}{0pt}
 \fancyhead[L]{\hspace{-0.75cm}\includegraphics[width=5.5cm]{$logo_path$}}
 \fancyhead[C]{}
@@ -140,7 +145,7 @@ $endif$
 \renewcommand{\footrulewidth}{0.25pt}
 
 \fancyfoot[L]{\parbox[t]{0.98\headwidth}{\footnotesize{\sffamily $self-citation$}.}}
-
+$endif$
 
 \fancyfoot[R]{\sffamily \thepage}
 \makeatletter
@@ -293,10 +298,13 @@ $if(tables)$
 \usepackage{longtable,booktabs,array}
 $endif$
 $-- add watermark and linenumbers unless this is the final (non-draft) version
+$if(arxiv)$
+$else$
 $if(draft)$
 \usepackage{lineno}
 \linenumbers
 \usepackage{draftwatermark}
+$endif$
 $endif$
 
 $if(graphics)$
@@ -414,6 +422,9 @@ $abstract$
 \end{abstract}
 $endif$
 
+$if(arxiv)$
+% Omitting any info on software, editor, and reviewers.
+$else$
 \marginpar{
 
   \begin{flushleft}
@@ -483,6 +494,7 @@ $endif$
 
   \end{flushleft}
 }
+$endif$
 
 $for(include-before)$
 $include-before$


### PR DESCRIPTION
A new output format `arxiv` is added, which will generate a LaTeX file
`paper.arxiv` that has no JOSS logos and no metadata sidebar.  However,
the general styling is retained.