### PR TITLE
PDF: Add setting to parse raw LaTeX snippets

### DIFF
--- a/data/filters/parse-latex.lua
+++ b/data/filters/parse-latex.lua
@@ -1,24 +1,32 @@
-if FORMAT:match 'latex' then
-  return {}
-end
+function Pandoc (doc)
+  local allow_raw_latex =
+    doc.meta['raw-latex'] == true or
+    doc.meta['raw-latex'] == nil
 
-function RawBlock (raw)
-  if raw.format:match 'tex' then
-    return pandoc.read(
-      -- special case: pandoc does not know how to parse a resizebox command
-      raw.text:gsub('\\resizebox%{.-%}%{%!%}(%b{})', '%1'),
-      'latex'
-    ).blocks
+  if FORMAT:match 'latex' and allow_raw_latex then
+    return nil  -- do nothing
   end
-  if raw.format == 'tex' then
-    return {}
-  end
-end
 
-function RawInline(raw)
-  if raw.format:match 'tex' then
-    return pandoc.utils.blocks_to_inlines(
-      pandoc.read(raw.text, 'latex').blocks
-    )
-  end
+  return doc:walk {
+    RawBlock = function (raw)
+      if raw.format:match 'tex' then
+        return pandoc.read(
+          -- special case: pandoc does not know how to parse a resizebox command
+          raw.text:gsub('\\resizebox%{.-%}%{%!%}(%b{})', '%1'),
+          'latex'
+        ).blocks
+      end
+      if raw.format == 'tex' then
+        return {}
+      end
+    end,
+
+    RawInline = function (raw)
+      if raw.format:match 'tex' then
+        return pandoc.utils.blocks_to_inlines(
+          pandoc.read(raw.text, 'latex').blocks
+        )
+      end
+    end
+  }
 end


### PR DESCRIPTION
If the metadata value `raw-latex` is set to a truthy value, then raw LaTeX snippets are not passed through verbatim, but parsed into pandoc's internal document representation.

The value is disabled by default, but can be enabled by authors. It will be enabled by default in the future.