### PR TITLE
Improve ORCID handling

### DIFF
--- a/data/defaults/jats.yaml
+++ b/data/defaults/jats.yaml
@@ -13,6 +13,12 @@ filters:
     type: lua
     path: remove-references-heading.lua
 
+  - # Turn ORCID identifiers into proper URIs; this is the generic
+    # representation required by the spec, but impractical to use with LaTeX. We
+    # do it here for that reason.
+    type: lua
+    path: orcid-uri.lua
+
 # This needs more work before we can really enable it.
 #   - type: lua
 #     path: extract-images.lua

--- a/data/filters/orcid-uri.lua
+++ b/data/filters/orcid-uri.lua
@@ -1,0 +1,9 @@
+-- Creates the ORCID numbers into a URI.
+function Meta (meta)
+  for _, author in ipairs(meta.author or {}) do
+    if type(author.orcid) == 'string' then
+      author.orcid = 'https://orcid.org/' .. author.orcid
+    end
+  end
+  return meta
+end


### PR DESCRIPTION
Remove invalid ORCID identifiers and use an URI in JATS, as required by ORCID.

Fixes: #24