### PR TITLE
fix double guillemet » ligature in code

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -230,7 +230,7 @@ $endif$
   \else
     \usepackage{fontspec}
   \fi
-  \defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}
+  \defaultfontfeatures{Ligatures=Common,Scale=MatchLowercase}
 
 \fi
 % use upquote if available, for straight quotes in verbatim environments


### PR DESCRIPTION
When `>>` appears in code blocks, it is currently processed as a ligature, resulting in a double guillemet `»`. This avoids such ligature handling globally, though it should be possible to restrict it only to code blocks. I think the `TeX` ligatures are surprising, especially for those authoring in Markdown.