### PR TITLE
Update checkout action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build image
         run: |

--- a/.github/workflows/example-doc.yml
+++ b/.github/workflows/example-doc.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build PDF
         run: >-


### PR DESCRIPTION
This PR updates the [checkout action](https://github.com/actions/checkout) in both image builder & compiler workflows to use the latest v3 version. 

[Version 2 was deprecated](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) in favor of v3 to update the node dependency from node12 to node 16.