### PR TITLE
Add missing dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,13 @@ RUN tlmgr update --self && tlmgr install \
   float \
   fontspec \
   fontsetup \
+  hyperxmp \
+  ifmtarg \
   latexmk \
   lineno \
   listings \
+  luacode \
+  lualatex-math \
   logreq \
   marginnote \
   mathspec \
@@ -26,7 +30,9 @@ RUN tlmgr update --self && tlmgr install \
   orcidlink \
   pgf \
   preprint \
+  selnolig \
   seqsplit \
+  soul \
   tcolorbox \
   titlesec \
   trimspaces \

--- a/README.md
+++ b/README.md
@@ -62,3 +62,5 @@ The latest pandoc version can be downloaded from
 
 PDFs are generated via LaTeX; for best results, all packages
 listed in `Dockerfile` should be installed.
+
+You will also need the [Hack](https://github.com/source-foundry/Hack) font by `source-foundry`.


### PR DESCRIPTION
Running from a basictex install, found a number of dependencies that are missed in the dockerfile (i assume they're installed in the base image). 

Also added a note to install the hack font, which is done in the docker image but not mentioned in README