### PR TITLE
[Feature] Mermaid and graphviz diagrams

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,13 @@ RUN tlmgr update --self && tlmgr install \
   float \
   fontspec \
   fontsetup \
+  hyperxmp \
+  ifmtarg \
   latexmk \
   lineno \
   listings \
+  luacode \
+  lualatex-math \
   logreq \
   marginnote \
   mathspec \
@@ -26,7 +30,9 @@ RUN tlmgr update --self && tlmgr install \
   orcidlink \
   pgf \
   preprint \
+  selnolig \
   seqsplit \
+  soul \
   tcolorbox \
   titlesec \
   trimspaces \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,11 @@ FROM pandoc/latex:3.1.1-alpine
 
 RUN apk add --no-cache ttf-hack
 
+# Install dependencies for diagrams
+RUN apk add --no-cache graphviz
+RUN apk add --no-cache nodejs
+RUN npm install -g @mermaid-js/mermaid-cli
+
 # Install additional LaTeX packages
 RUN tlmgr update --self && tlmgr install \
   algorithmicx \

--- a/README.md
+++ b/README.md
@@ -62,3 +62,5 @@ The latest pandoc version can be downloaded from
 
 PDFs are generated via LaTeX; for best results, all packages
 listed in `Dockerfile` should be installed.
+
+You will also need the [Hack](https://github.com/source-foundry/Hack) font by `source-foundry`.

--- a/README.md
+++ b/README.md
@@ -64,3 +64,8 @@ PDFs are generated via LaTeX; for best results, all packages
 listed in `Dockerfile` should be installed.
 
 You will also need the [Hack](https://github.com/source-foundry/Hack) font by `source-foundry`.
+
+To render diagrams you will need to have installed the relevant diagram library:
+
+- mermaid: `npm install -g @mermaid-js/mermaid-cli`
+- graphviz: ([consult docs](https://graphviz.org/download/))

--- a/data/defaults/shared.yaml
+++ b/data/defaults/shared.yaml
@@ -8,6 +8,13 @@ metadata:
   # cannot be overwritten in the paper YAML.
   lang: 'en-US'
 
+  engine:
+    dot: true
+    plantuml: false
+    asymptote: false
+    mermaid: true
+    tikz: false
+
 resource-path:
   - '/usr/local/share/openjournals'
   - '.'
@@ -27,6 +34,8 @@ filters:
     path: normalize-author-names.lua
   - type: lua
     path: substitute-in-format.lua
+  - type: lua
+    path: diagram.lua
 
 # ERROR, WARNING, or INFO
 verbosity: INFO

--- a/data/filters/diagram.lua
+++ b/data/filters/diagram.lua
@@ -1,0 +1,1 @@
+../../vendor/diagram-1.0.0/_extensions/diagram/diagram.lua

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -1,7 +1,7 @@
 \documentclass[10pt,a4paper,onecolumn]{article}
 \usepackage{marginnote}
 \usepackage{graphicx}
-\usepackage[rgb]{xcolor}
+\usepackage[rgb,svgnames]{xcolor}
 \usepackage{authblk,etoolbox}
 \usepackage{titlesec}
 \usepackage{calc}
@@ -79,25 +79,38 @@ $endif$
 \usepackage{fixltx2e} % provides \textsubscript
 
 $if(csl-refs)$
+% definitions for citeproc citations
+\NewDocumentCommand\citeproctext{}{}
+\NewDocumentCommand\citeproc{mm}{%
+  \begingroup\def\citeproctext{#2}\cite{#1}\endgroup}
+\makeatletter
+ % allow citations to break across lines
+ \let\@cite@ofmt\@firstofone
+ % avoid brackets around text for \cite:
+ \def\@biblabel#1{}
+ \def\@cite#1#2{{#1\if@tempswa , #2\fi}}
+\makeatother
 \newlength{\cslhangindent}
 \setlength{\cslhangindent}{1.5em}
 \newlength{\csllabelwidth}
 \setlength{\csllabelwidth}{3em}
-\newenvironment{CSLReferences}[2] % #1 hanging-ident, #2 entry spacing
- {% don't indent paragraphs
-  \setlength{\parindent}{0pt}
+\newenvironment{CSLReferences}[2] % #1 hanging-indent, #2 entry-spacing
+ {\begin{list}{}{%
+  \setlength{\itemindent}{0pt}
+  \setlength{\leftmargin}{0pt}
+  \setlength{\parsep}{0pt}
   % turn on hanging indent if param 1 is 1
-  \ifodd #1 \everypar{\setlength{\hangindent}{\cslhangindent}}\ignorespaces\fi
-  % set entry spacing
-  \ifnum #2 > 0
-  \setlength{\parskip}{#2\baselineskip}
+  \ifodd #1
+   \setlength{\leftmargin}{\cslhangindent}
+   \setlength{\itemindent}{-1\cslhangindent}
   \fi
- }%
- {}
+  % set entry spacing
+  \setlength{\itemsep}{#2\baselineskip}}}
+ {\end{list}}
 \usepackage{calc}
-\newcommand{\CSLBlock}[1]{#1\hfill\break}
-\newcommand{\CSLLeftMargin}[1]{\parbox[t]{\csllabelwidth}{#1}}
-\newcommand{\CSLRightInline}[1]{\parbox[t]{\linewidth - \csllabelwidth}{#1}\break}
+\newcommand{\CSLBlock}[1]{\hfill\break\parbox[t]{\linewidth}{\strut\ignorespaces#1\strut}}
+\newcommand{\CSLLeftMargin}[1]{\parbox[t]{\csllabelwidth}{\strut#1\strut}}
+\newcommand{\CSLRightInline}[1]{\parbox[t]{\linewidth - \csllabelwidth}{\strut#1\strut}}
 \newcommand{\CSLIndent}[1]{\hspace{\cslhangindent}#1}
 $endif$
 

--- a/data/templates/preprint.latex
+++ b/data/templates/preprint.latex
@@ -127,7 +127,7 @@ $endif$
 $if(verbatim-in-note)$
 \usepackage{fancyvrb}
 $endif$
-\usepackage{xcolor}
+\usepackage[rgb,svgnames]{xcolor}
 $if(listings)$
 \usepackage{listings}
 \newcommand{\passthrough}[1]{#1}
@@ -200,28 +200,38 @@ $if(pagestyle)$
 \pagestyle{$pagestyle$}
 $endif$
 $if(csl-refs)$
+% definitions for citeproc citations
+\NewDocumentCommand\citeproctext{}{}
+\NewDocumentCommand\citeproc{mm}{%
+  \begingroup\def\citeproctext{#2}\cite{#1}\endgroup}
+\makeatletter
+ % allow citations to break across lines
+ \let\@cite@ofmt\@firstofone
+ % avoid brackets around text for \cite:
+ \def\@biblabel#1{}
+ \def\@cite#1#2{{#1\if@tempswa , #2\fi}}
+\makeatother
 \newlength{\cslhangindent}
 \setlength{\cslhangindent}{1.5em}
 \newlength{\csllabelwidth}
 \setlength{\csllabelwidth}{3em}
-\newlength{\cslentryspacingunit} % times entry-spacing
-\setlength{\cslentryspacingunit}{\parskip}
-\newenvironment{CSLReferences}[2] % #1 hanging-ident, #2 entry spacing
- {% don't indent paragraphs
-  \setlength{\parindent}{0pt}
+\newenvironment{CSLReferences}[2] % #1 hanging-indent, #2 entry-spacing
+ {\begin{list}{}{%
+  \setlength{\itemindent}{0pt}
+  \setlength{\leftmargin}{0pt}
+  \setlength{\parsep}{0pt}
   % turn on hanging indent if param 1 is 1
   \ifodd #1
-  \let\oldpar\par
-  \def\par{\hangindent=\cslhangindent\oldpar}
+   \setlength{\leftmargin}{\cslhangindent}
+   \setlength{\itemindent}{-1\cslhangindent}
   \fi
   % set entry spacing
-  \setlength{\parskip}{#2\cslentryspacingunit}
- }%
- {}
+  \setlength{\itemsep}{#2\baselineskip}}}
+ {\end{list}}
 \usepackage{calc}
-\newcommand{\CSLBlock}[1]{#1\hfill\break}
-\newcommand{\CSLLeftMargin}[1]{\parbox[t]{\csllabelwidth}{#1}}
-\newcommand{\CSLRightInline}[1]{\parbox[t]{\linewidth - \csllabelwidth}{#1}\break}
+\newcommand{\CSLBlock}[1]{\hfill\break\parbox[t]{\linewidth}{\strut\ignorespaces#1\strut}}
+\newcommand{\CSLLeftMargin}[1]{\parbox[t]{\csllabelwidth}{\strut#1\strut}}
+\newcommand{\CSLRightInline}[1]{\parbox[t]{\linewidth - \csllabelwidth}{\strut#1\strut}}
 \newcommand{\CSLIndent}[1]{\hspace{\cslhangindent}#1}
 $endif$
 $if(lang)$

--- a/example/paper.md
+++ b/example/paper.md
@@ -279,6 +279,120 @@ Rendered:
    gained as heat, $Q$, less the thermodynamic work, $W$, done by the
    system on its surroundings. $$\Delta U = Q - W$$
 
+### Code examples
+
+Code examples can be written in fenced code blocks and highlighted with the provided language. 
+
+For example:
+
+```` 
+```python
+import shutil
+
+def hello_world():
+    # shutil.rmtree('/')
+    # on second thought
+    print('hello world')
+```
+````
+
+creates:
+
+```python
+import shutil
+
+def hello_world():
+    # shutil.rmtree('/')
+    # on second thought
+    print('hello world')
+```
+
+### Diagrams
+
+Diagrams[^diagrams] can be written within fenced code blocks using:
+
+[^diagrams]: Thanks to the [pandoc-ext/diagram](https://github.com/pandoc-ext/diagram/tree/main) pandoc filter
+
+- [`mermaid`](https://mermaid.js.org/)
+- `dot` ([graphviz](https://graphviz.org/))
+
+See the linked documentation for more information on available diagram types and syntax, particularly with mermaid which is under active development.
+
+For example, using mermaid:
+
+```` markdown
+``` mermaid
+%%| label: open_review
+%%| caption: Open Software Review: a state diagram
+stateDiagram-v2
+  direction LR
+  Ship: Ship It
+  [*] --> Code
+  Code --> Compile
+  Compile --> Bug
+  Bug --> Cry
+  Cry --> Code
+  Bug --> YOLO
+  YOLO --> Ship
+  Ship --> [*]
+```
+````
+
+Creates:
+
+``` mermaid
+%%| label: open_source
+%%| caption: Open Source: a state diagram
+stateDiagram-v2
+  direction LR
+  Ship: Ship It
+  [*] --> Code
+  Code --> Compile
+  Compile --> Bug
+  Bug --> Cry
+  Cry --> Code
+  Bug --> YOLO
+  YOLO --> Ship
+  Ship --> [*]
+```
+
+Similarly, with dot/graphviz:
+
+````markdown
+``` dot
+digraph {
+  rankdir=LR
+  submit -> read
+  subgraph cluster_review {
+      label="review"
+      read -> issue
+      issue -> PR
+      PR -> read
+  }
+  read -> lgtm
+  lgtm -> thanks[label="say thanks"]
+  thanks -> friends[label="make friends!"]
+}
+```
+````
+
+Creates:
+
+``` dot
+digraph {
+  rankdir=LR
+  submit -> read
+  subgraph cluster_review {
+      label="review"
+      read -> issue
+      issue -> PR
+      PR -> read
+  }
+  read -> lgtm
+  lgtm -> thanks[label="say thanks"]
+  thanks -> friends[label="make friends!"]
+}
+```
 
 # Article metadata
 

--- a/vendor/diagram-1.0.0/.gitignore
+++ b/vendor/diagram-1.0.0/.gitignore
@@ -1,0 +1,2 @@
+sample.html
+tmp-latex

--- a/vendor/diagram-1.0.0/CHANGELOG.md
+++ b/vendor/diagram-1.0.0/CHANGELOG.md
@@ -1,0 +1,11 @@
+# diagram
+
+The diagram filter is versioned using [Semantic Versioning][].
+
+[Semantic Versioning]: https://semver.org/
+
+## v1.0.0
+
+Released 2023-05-22.
+
+- First release of the Lua filter; may it live long and prosper.

--- a/vendor/diagram-1.0.0/LICENSE
+++ b/vendor/diagram-1.0.0/LICENSE
@@ -1,0 +1,24 @@
+MIT License
+
+Copyright © 2019-2023 Albert Krewinkel
+Copyright © 2019 Thorsten Sommer
+Copyright © 2018 Florian Schätzig
+Copyright © 2018 John MacFarlane
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/diagram-1.0.0/Makefile
+++ b/vendor/diagram-1.0.0/Makefile
@@ -1,0 +1,22 @@
+FILTER_FILE := $(wildcard *.lua)
+PANDOC ?= pandoc
+DIFF ?= diff
+
+.PHONY: test
+test: test-asymptote test-dot test-mermaid test-plantuml test-tikz \
+	test-no-alt-or-caption
+
+test-%: test/test-%.yaml test/input-%.md $(FILTER_FILE)
+	@$(PANDOC) --defaults test/test-$*.yaml | \
+	  $(DIFF) test/expected-$*.html -
+
+sample.html: sample.md diagram.lua
+	@$(PANDOC) --self-contained \
+	    --lua-filter=diagram.lua \
+	    --metadata=pythonPath:"python3" \
+	    --metadata=title:"README" \
+	    --output=$@ $<
+
+clean:
+	@rm -f sample.html
+	@rm -rf tmp-latex

--- a/vendor/diagram-1.0.0/README.md
+++ b/vendor/diagram-1.0.0/README.md
@@ -1,0 +1,236 @@
+Diagram Generator
+=================
+
+This Lua filter is used to create figures from code blocks: images
+are generated from the code with the help of external programs.
+The filter processes diagram code for Asymptote, Graphviz,
+Mermaid, PlantUML, and Ti*k*Z.
+
+
+Usage
+-----
+
+The filter modifies the internal document representation; it can
+be used with many publishing systems that are based on pandoc.
+
+### Plain pandoc
+
+Pass the filter to pandoc via the `--lua-filter` (or `-L`) command
+line option.
+
+    pandoc --lua-filter diagram.lua ...
+
+### Quarto
+
+Users of Quarto can install this filter as an extension with
+
+    quarto install extension pandoc-ext/diagram
+
+and use it by adding `diagram` to the `filters` entry in their
+YAML header.
+
+``` yaml
+---
+filters:
+  - diagram
+---
+``**
+
+**Note**: Quarto comes with its own system for diagram generation;
+we recommend to use Quarto's built-in diagram options when
+possible, especially for Mermaid diagrams.
+
+### R Markdown
+
+Use `pandoc_args` to invoke the filter. See the [R Markdown
+Cookbook](https://bookdown.org/yihui/rmarkdown-cookbook/lua-filters.html)
+for details.
+
+``` yaml
+---
+output:
+  word_document:
+    pandoc_args: ['--lua-filter=diagram.lua']
+---
+```
+
+Diagram types
+-------------
+
+The table below lists the supported diagram drawing systems, the
+class that must be used for the system, and the main executable
+that the filter calls to generate an image from the code. The
+*environment variables* column lists the names of env variables
+that can be used to specify a specific executable.
+
+| System      | code block class  | executable | env variable    |
+|-------------|-------------------|------------|-----------------|
+| [Asymptote] | `asymptote`       | `asy`      | `ASYMPTOTE_BIN` |
+| [GraphViz]  | `dot`             | `dot`      | `DOT_BIN`       |
+| [Mermaid]   | `mermaid`         | `mmdc`     | `MERMAID_BIN`   |
+| [PlantUML]  | `plantuml`        | `plantuml` | `PLANTUML_BIN`  |
+| [Ti*k*Z]    | `tikz`            | `pdflatex` | `PDFLATEX_BIN`  |
+
+### Other diagram engines
+
+The filter can be extended with local packages; see
+[Configuration](#configuration) below.
+
+[Asymptote]: https://asymptote.sourceforge.io/
+[GraphViz]: https://www.graphviz.org/
+[Mermaid]: https://mermaid.js.org/
+[PlantUML]: https://plantuml.org/
+[Ti*k*Z]: https://en.wikipedia.org/wiki/PGF/TikZ
+
+Figure options
+--------------
+
+Options can be given using the syntax pioneered by [Quarto]:
+
+````
+``` {.dot}
+//| label: fig-boring
+//| fig-cap: "A boring Graphviz graph."
+digraph boring {
+  A -> B;
+}
+```
+````
+
+[Quarto]: https://quarto.org/
+
+Configuration
+-------------
+
+The filter can be configured with the `diagram` metadata entry.
+
+Currently supported options:
+
+- `cache`: controls whether the images are cached. If the cache is
+  enabled, then the images are recreated only when their code
+  changes. This option is *disabled* by default.
+
+- `cache-dir`: Sets the directory in which the images are cached.
+  The default is to use the `pandoc-diagram-filter` subdir of the
+  a common caching location. This will be, in the order of
+  preference, the value of the `XDG_CACHE_HOME` environment
+  variable if it is set, or alternatively `%USERPROFILE%\.cache` on
+  Windows and `$HOME/.cache` on all other platforms.
+
+  Caching is disabled if none of the environment variables
+  mentioned above has been defined.
+
+- `engine`: options for specific engines, e.g. `plantuml` or
+  `mermaid`. The options must be nested below the engine name.
+  Allowed settings are either `true` or `false` to enable or
+  disable the engine, respectively, or a a map of options.
+  The available settings are:
+
+  + `mime-type`: the output MIME type that should be produced with
+    this engine. This can be used to choose a specific type, or to
+    disable certain output formats. For example, the below
+    disables support for PDF output in PlantUML, which can be
+    useful when the necessary libraries are unavailable on a
+    system:
+
+    ``` yaml
+    diagram:
+      engine:
+        plantuml:
+          mime-type:
+            application/pdf: false
+    ```
+
+  + `line_comment_start`: the character sequence that starts a
+    line comment; unset or change this to disable or modify the
+    syntax of user options in the diagram code.
+
+  + `execpath`: the path to the engine's executable. Use this to
+    override the default executable name listed in the table
+    above.
+
+  + `package`: if this option is set then the filter will try to
+    `require` a Lua package with the given name. If the operation
+    is successful, then the result will be used as the compiler
+    for that diagram type.
+
+  + Any other option is passed through to the engine. See the
+    engine-specific settings below.
+
+### Engine-specific options
+
+Some engines accept additional options. These options can either
+be passed globally as part of the respective `engine` entry, or
+locally by adding `opt-NAME` as an attribute to the diagram code
+block. Global options always override local options for security
+reasons.
+
+#### Ti*k*Z
+
+The Ti*k*Z engine accepts the `header-includes` and
+`additional-packages` options. Both options are added to the
+intermediary TeX file that is used to produce the output file. The
+options differ only in how string values are handled, with bare
+strings in `header-includes` being escaped and those in
+`additional-packages` being treated as TeX code.
+
+While mentioned above, it should be highlighted that the
+`execpath` option can be used to select a specific LaTeX engine.
+The default is `pdflatex`.
+
+Example:
+
+``` yaml
+---
+diagram:
+  engine:
+    tikz:
+      execpath: lualatex
+      include-headers:
+        - '\usepackage{adjustbox}'
+        - '\usetikzlibrary{arrows, shapes}'
+---
+```
+
+Security
+--------
+
+This filter **should not** be used with **untrusted documents**,
+***unless*** local configs prevent the setting of filter options
+in the metadata: An attacker that can set the execpath for an
+engine can execute any binary on the system with the user's
+permissions. It is hence recommended to review any document before
+using it with this filter to avoid malicious and misuse of the
+filter.
+
+The security is improved considerably if the `diagram` metadata
+field is unset or set to a predefined value before this filter is
+called, e.g., via another filter or a defaults file.
+
+Here is an example defaults file that configures the filter such
+that the configs cannot be overwritten by the document.
+
+``` yaml
+# file: diagram-filter.yaml
+filters: ['diagram.lua']
+metadata:
+  engine:
+    # enable dot/GraphViz and PlantUML with default options
+    dot: true
+    plantuml: true
+
+    # disable processing of asymptote and Mermaid diagrams
+    asymptote: false
+    mermaid: false
+
+    # Use LuaLaTeX to compile TikZ, define headers
+    tikz:
+      execpath: lualatex
+      additional-packages: |
+        \usepackage{adjustbox}
+        \usetikzlibrary{arrows, shapes}
+```
+
+Usage:
+
+    pandoc -d diagram-filter ...

--- a/vendor/diagram-1.0.0/_extensions/diagram/_extension.yaml
+++ b/vendor/diagram-1.0.0/_extensions/diagram/_extension.yaml
@@ -1,0 +1,7 @@
+title: diagram
+author: Albert Krewinkel
+version: 1.0.0
+quarto-required: ">=1.3"
+contributes:
+  filters:
+    - diagram.lua

--- a/vendor/diagram-1.0.0/_extensions/diagram/diagram.lua
+++ b/vendor/diagram-1.0.0/_extensions/diagram/diagram.lua
@@ -1,0 +1,524 @@
+--[[
+diagram-generator – create images and figures from code blocks.
+
+See copyright notice in file LICENSE.
+]]
+-- Module pandoc.system is required and was added in version 2.7.3
+PANDOC_VERSION:must_be_at_least '3.0'
+
+-- Report Lua warnings to stderr
+if warn then
+  warn '@on'
+else
+  warn = function (...) io.stderr:write(string.concat({...})) end
+end
+
+local system = require 'pandoc.system'
+local utils = require 'pandoc.utils'
+local stringify = utils.stringify
+local with_temporary_directory = system.with_temporary_directory
+local with_working_directory = system.with_working_directory
+
+--- Returns a filter-specific directory in which cache files can be
+--- stored, or nil if no such directory is available.
+local function cachedir ()
+  local cache_home = os.getenv 'XDG_CACHE_HOME'
+  if not cache_home or cache_home == '' then
+    local user_home = system.os == 'windows'
+      and os.getenv 'USERPROFILE'
+      or os.getenv 'HOME'
+
+    if not user_home or user_home == '' then
+      return nil
+    end
+    cache_home = pandoc.path.join{user_home, '.cache'} or nil
+  end
+
+  -- Create filter cache directory
+  return pandoc.path.join{cache_home, 'pandoc-diagram-filter'}
+end
+
+--- Path holding the image cache, or `nil` if the cache is not used.
+local image_cache = nil
+
+local mimetype_for_extension = {
+  jpeg = 'image/jpeg',
+  jpg = 'image/jpeg',
+  pdf = 'application/pdf',
+  png = 'image/png',
+  svg = 'image/svg+xml',
+}
+
+local extension_for_mimetype = {
+  ['application/pdf'] = 'pdf',
+  ['image/jpeg'] = 'jpg',
+  ['image/png'] = 'png',
+  ['image/svg+xml'] = 'svg',
+}
+
+--- Converts a list of format specifiers to a set of MIME types.
+local function mime_types_set (tbl)
+  local set = {}
+  local mime_type
+  for _, image_format_spec in ipairs(tbl) do
+    mime_type = mimetype_for_extension[image_format_spec] or image_format_spec
+    set[mime_type] = true
+  end
+  return set
+end
+
+--- Reads the contents of a file.
+local function read_file (filepath)
+  local fh = io.open(filepath, 'rb')
+  local contents = fh:read('a')
+  fh:close()
+  return contents
+end
+
+--- Writes the contents into a file at the given path.
+local function write_file (filepath, content)
+  local fh = io.open(filepath, 'wb')
+  fh:write(content)
+  fh:close()
+end
+
+--
+-- Diagram Engines
+--
+
+-- PlantUML engine; assumes that there's a `plantuml` binary.
+local plantuml = {
+  line_comment_start =  [[']],
+  mime_types = mime_types_set{'pdf', 'png', 'svg'},
+  compile = function (self, puml)
+    local mime_type = self.mime_type or 'image/svg+xml'
+    -- PlantUML format identifiers correspond to common file extensions.
+    local format = extension_for_mimetype[mime_type]
+    if not format then
+      format, mime_type = 'svg', 'image/svg+xml'
+    end
+    local args = {'-t' .. format, "-pipe", "-charset", "UTF8"}
+    return pandoc.pipe(self.execpath or 'plantuml', args, puml), mime_type
+  end,
+}
+
+--- GraphViz engine for the dot language
+local graphviz = {
+  line_comment_start = '//',
+  mime_types = mime_types_set{'jpg', 'pdf', 'png', 'svg'},
+  mime_type = 'image/svg+xml',
+  compile = function (self, code)
+    local mime_type = self.mime_type
+    -- GraphViz format identifiers correspond to common file extensions.
+    local format = extension_for_mimetype[mime_type]
+    if not format then
+      format, mime_type = 'svg', 'image/svg+xml'
+    end
+    return pandoc.pipe(self.execpath or 'dot', {"-T"..format}, code), mime_type
+  end,
+}
+
+--- Mermaid engine
+local mermaid = {
+  line_comment_start = '%%',
+  mime_types = mime_types_set{'pdf', 'png', 'svg'},
+  compile = function (self, code)
+    local mime_type = self.mime_type or 'image/svg+xml'
+    local file_extension = extension_for_mimetype[mime_type]
+    return with_temporary_directory("diagram", function (tmpdir)
+      return with_working_directory(tmpdir, function ()
+        local infile = 'diagram.mmd'
+        local outfile = 'diagram.' .. file_extension
+        write_file(infile, code)
+        pandoc.pipe(
+          self.execpath or 'mmdc',
+          {"--pdfFit", "--input", infile, "--output", outfile},
+          ''
+        )
+        return read_file(outfile), mime_type
+      end)
+    end)
+  end,
+}
+
+--- TikZ
+--
+
+--- LaTeX template used to compile TikZ images. Takes additional
+--- packages as the first, and the actual TikZ code as the second
+--- argument.
+local tikz_template = pandoc.template.compile [[
+\documentclass{standalone}
+\usepackage{tikz}
+$for(header-includes)$
+$it$
+$endfor$
+$additional-packages$
+\begin{document}
+$body$
+\end{document}
+]]
+
+--- The TikZ engine uses pdflatex to compile TikZ code to an image
+local tikz = {
+  line_comment_start = '%%',
+
+  mime_types = {
+    ['application/pdf'] = true,
+  },
+
+  --- Compile LaTeX with TikZ code to an image
+  compile = function (self, src, user_opts)
+    return with_temporary_directory("tikz", function (tmpdir)
+      return with_working_directory(tmpdir, function ()
+        -- Define file names:
+        local file_template = "%s/tikz-image.%s"
+        local tikz_file = file_template:format(tmpdir, "tex")
+        local pdf_file = file_template:format(tmpdir, "pdf")
+
+        -- Treat string values as raw LaTeX
+        local meta = {
+          ['header-includes'] = user_opts['header-includes'],
+          ['additional-packages'] = {pandoc.RawInline(
+            'latex',
+            stringify(user_opts['additional-packages'] or '')
+          )},
+        }
+        local tex_code = pandoc.write(
+          pandoc.Pandoc({pandoc.RawBlock('latex', src)}, meta),
+          'latex',
+          {template = tikz_template}
+        )
+        write_file(tikz_file, tex_code)
+
+        -- Execute the LaTeX compiler:
+        pandoc.pipe(
+          self.execpath or 'pdflatex',
+          {'-output-directory', tmpdir, tikz_file},
+          ''
+        )
+
+        return read_file(pdf_file), 'application/pdf'
+      end)
+    end)
+  end
+}
+
+--- Asymptote diagram engine
+local asymptote = {
+  line_comment_start = '%%',
+  mime_types = {
+    ['application/pdf'] = true,
+  },
+  compile = function (self, code)
+    return with_temporary_directory("asymptote", function(tmpdir)
+      return with_working_directory(tmpdir, function ()
+        local pdf_file = "pandoc_diagram.pdf"
+        local args = {'-tex', 'pdflatex', "-o", "pandoc_diagram", '-'}
+        pandoc.pipe(self.execpath or 'asy', args, code)
+        return read_file(pdf_file), 'application/pdf'
+      end)
+    end)
+  end,
+}
+
+local default_engines = {
+  asymptote = asymptote,
+  dot       = graphviz,
+  mermaid   = mermaid,
+  plantuml  = plantuml,
+  tikz      = tikz,
+}
+
+--
+-- Configuration
+--
+
+--- Options for the output format of the given name.
+local function format_options (name)
+  local pdf2svg = name ~= 'latex' and name ~= 'context'
+  local preferred_mime_types = pandoc.List{'application/pdf', 'image/png'}
+  -- Prefer SVG for non-PDF output formats
+  if pdf2svg then
+    preferred_mime_types:insert(1, 'image/svg+xml')
+  end
+  return {
+    name = name,
+    pdf2svg = pdf2svg,
+    preferred_mime_types = preferred_mime_types,
+    best_mime_type = function (self, supported_mime_types, requested)
+      return self.preferred_mime_types:find_if(function (preferred)
+          return supported_mime_types[preferred] and
+            (not requested or
+             (pandoc.utils.type(requested) == 'List' and
+              requested:includes(preferred)) or
+             (pandoc.utils.type(requested) == 'table' and
+              requested[preferred]) or
+
+             -- Assume string, Inlines, and Blocks values specify the only
+             -- acceptable MIME type.
+             stringify(requested) == preferred)
+      end)
+    end
+  }
+end
+
+--- Returns a configured diagram engine.
+local function get_engine (name, engopts, format)
+  local engine = default_engines[name] or
+    select(2, pcall(require, stringify(engopts.package)))
+
+  -- Sanity check
+  if not engine then
+    warn(PANDOC_SCRIPT_FILE, ": No such engine '", name, "'.")
+    return nil
+  elseif engopts == false then
+    -- engine is disabled
+    return nil
+  elseif engopts == true then
+    -- use default options
+    return engine
+  end
+
+  local execpath = engopts.execpath
+    and stringify(engopts.execpath)
+    or os.getenv(name:upper() .. '_BIN')
+
+  local mime_type = format:best_mime_type(
+    engine.mime_types,
+    engopts['mime-type'] or engopts['mime-types']
+  )
+  if not mime_type then
+    warn(PANDOC_SCRIPT_FILE, ": Cannot use ", name, " with ", format.name)
+    return nil
+  end
+
+  return {
+    execpath = execpath,
+    compile = engine.compile,
+    line_comment_start = engine.line_comment_start,
+    mime_type = mime_type,
+    opt = engopts or {},
+  }
+end
+
+--- Returns the diagram engine configs.
+local function configure (meta, format_name)
+  local conf = meta.diagram or {}
+  local format = format_options(format_name)
+  meta.diagram = nil
+
+  -- cache for image files
+  if conf.cache then
+    image_cache = conf['cache-dir']
+      and stringify(conf['cache-dir'])
+      or cachedir()
+    pandoc.system.make_directory(image_cache, true)
+  end
+
+  -- engine configs
+  local engine = {}
+  for name, engopts in pairs(conf.engine or default_engines) do
+    engine[name] = get_engine(name, engopts, format)
+  end
+
+  return {
+    engine = engine,
+    format = format,
+    cache = image_cache and true,
+    image_cache = image_cache,
+  }
+end
+
+
+--
+-- Format conversion
+--
+
+--- Converts a PDF to SVG.
+local pdf2svg = function (imgdata)
+  local pdf_file = os.tmpname() .. '.pdf'
+  write_file(pdf_file, imgdata)
+  local args = {
+    '--export-type=svg',
+    '--export-plain-svg',
+    '--export-filename=-',
+    pdf_file
+  }
+  return pandoc.pipe('inkscape', args, ''), os.remove(pdf_file)
+end
+
+local function properties_from_code (code, comment_start)
+  local props = {}
+  local pattern = comment_start:gsub('%p', '%%%1') .. '| ' ..
+    '([-_%w]+): ([^\n]*)\n'
+  for key, value in code:gmatch(pattern) do
+    if key == 'fig-cap' then
+      props['caption'] = value
+    else
+      props[key] = value
+    end
+  end
+  return props
+end
+
+local function diagram_options (cb, comment_start)
+  local attribs = comment_start
+    and properties_from_code(cb.text, comment_start)
+    or {}
+  for key, value in pairs(cb.attributes) do
+    attribs[key] = value
+  end
+
+  -- Read caption attribute as Markdown
+  local caption = attribs.caption
+    and pandoc.read(attribs.caption).blocks
+    or nil
+  local fig_attr = {
+    id = cb.identifier ~= '' and cb.identifier or attribs.label,
+    name = attribs.name,
+  }
+  local user_opt = {}
+
+  for k, v in pairs(attribs) do
+    local prefix, key = k:match '^(%a+)%-(%a[-%w]*)$'
+    if prefix == 'fig' then
+      fig_attr[key] = v
+    elseif prefix == 'opt' then
+      user_opt[key] = v
+    end
+  end
+
+  return {
+    ['alt'] = attribs.alt or
+      (caption and pandoc.utils.blocks_to_inlines(caption)) or
+      {},
+    ['caption'] = caption,
+    ['fig-attr'] = fig_attr,
+    ['filename'] = attribs.filename,
+    ['image-attr'] = {
+      height = attribs.height,
+      width = attribs.width,
+      style = attribs.style,
+    },
+    ['opt'] = user_opt,
+  }
+end
+
+local function get_cached_image (hash, mime_type)
+  if not image_cache then
+    return nil
+  end
+  local filename = hash .. '.' .. extension_for_mimetype[mime_type]
+  local imgpath = pandoc.path.join{image_cache, filename}
+  local success, imgdata = pcall(read_file, imgpath)
+  if success then
+    return imgdata, mime_type
+  end
+  return nil
+end
+
+local function cache_image (codeblock, imgdata, mimetype)
+  -- do nothing if caching is disabled or not possible.
+  if not image_cache then
+    return
+  end
+  local ext = extension_for_mimetype[mimetype]
+  local filename = pandoc.sha1(codeblock.text) .. '.' .. ext
+  local imgpath = pandoc.path.join{image_cache, filename}
+  write_file(imgpath, imgdata)
+end
+
+-- Executes each document's code block to find matching code blocks:
+local function code_to_figure (conf)
+  return function (block)
+    -- Check if a converter exists for this block. If not, return the block
+    -- unchanged.
+    local diagram_type = block.classes[1]
+    if not diagram_type then
+      return nil
+    end
+
+    local engine = conf.engine[diagram_type]
+    if not engine then
+      return nil
+    end
+
+    -- Unified properties.
+    local dgr_opt = diagram_options(block, engine.line_comment_start)
+    for optname, value in pairs(engine.opt or {}) do
+      dgr_opt.opt[optname] = dgr_opt.opt[optname] or value
+    end
+
+    local run_pdf2svg = engine.mime_type == 'application/pdf'
+      and conf.format.pdf2svg
+
+    -- Try to retrieve the image data from the cache.
+    local imgdata, imgtype
+    if conf.cache then
+      imgdata, imgtype = get_cached_image(
+        pandoc.sha1(block.text),
+        run_pdf2svg and 'image/svg+xml' or engine.mime_type
+      )
+    end
+
+    if not imgdata or not imgtype then
+      -- No cached image; call the converter
+      local success
+      success, imgdata, imgtype =
+        pcall(engine.compile, engine, block.text, dgr_opt.opt)
+
+      -- Bail if an error occurred; imgdata contains the error message
+      -- when that happens.
+      if not success then
+        warn(PANDOC_SCRIPT_FILE, ': ', tostring(imgdata))
+        return nil
+      elseif not imgdata then
+        warn(PANDOC_SCRIPT_FILE, ': Diagram engine returned no image data.')
+        return nil
+      elseif not imgtype then
+        warn(PANDOC_SCRIPT_FILE, ': Diagram engine did not return a MIME type.')
+        return nil
+      end
+
+      -- Convert SVG if necessary.
+      if imgtype == 'application/pdf' and conf.format.pdf2svg then
+        imgdata, imgtype = pdf2svg(imgdata), 'image/svg+xml'
+      end
+
+      -- If we got here, then the transformation went ok and `img` contains
+      -- the image data.
+      cache_image(block, imgdata, imgtype)
+    end
+
+    -- Use the block's filename attribute or create a new name by hashing the
+    -- image content.
+    local basename, _extension = pandoc.path.split_extension(
+      dgr_opt.filename or pandoc.sha1(imgdata)
+    )
+    local fname = basename .. '.' .. extension_for_mimetype[imgtype]
+
+    -- Store the data in the media bag:
+    pandoc.mediabag.insert(fname, imgtype, imgdata)
+
+    -- Create the image object.
+    local image = pandoc.Image(dgr_opt.alt, fname, "", dgr_opt['image-attr'])
+
+    -- Create a figure if the diagram has a caption; otherwise return
+    -- just the image.
+    return dgr_opt.caption and
+      pandoc.Figure(
+        pandoc.Plain{image},
+        dgr_opt.caption,
+        dgr_opt['fig-attr']
+      ) or
+      pandoc.Plain{image}
+  end
+end
+
+function Pandoc (doc)
+  local conf = configure(doc.meta, FORMAT)
+  return doc:walk {
+    CodeBlock = code_to_figure(conf),
+  }
+end

--- a/vendor/diagram-1.0.0/diagram.lua
+++ b/vendor/diagram-1.0.0/diagram.lua
@@ -1,0 +1,1 @@
+_extensions/diagram/diagram.lua

--- a/vendor/diagram-1.0.0/sample.md
+++ b/vendor/diagram-1.0.0/sample.md
@@ -1,0 +1,305 @@
+# Diagram Generator Lua Filter
+
+## Introduction
+This Lua filter is used to create images with or without captions from code
+blocks. Currently PlantUML, Graphviz, Ti*k*Z, Asymptote, and Python can be
+processed. This document also serves as a test document, which is why the
+subsequent test diagrams are integrated in every supported language.
+
+## Prerequisites
+To be able to use this Lua filter, the respective external tools must be
+installed. However, it is sufficient if the tools to be used are installed.
+If you only want to use PlantUML, you don't need LaTeX or Python, etc.
+
+### PlantUML
+To use PlantUML, you must install PlantUML itself. See the
+[PlantUML website](http://plantuml.com/) for more details. It should be
+noted that PlantUML is a Java program and therefore Java must also
+be installed.
+
+By default, this filter expects the plantuml.jar file to be in the
+working directory. Alternatively, the environment variable
+`PLANTUML` can be set with a path. If, for example, a specific
+PlantUML version is to be used per pandoc document, the
+`plantuml_path` meta variable can be set.
+
+Furthermore, this filter assumes that Java is located in the
+system or user path. This means that from any place of the system
+the `java` command is understood. Alternatively, the `JAVA_HOME`
+environment variable gets used. To use a specific Java version per
+pandoc document, use the `java_path` meta variable. Please notice
+that `JAVA_HOME` must be set to the java's home directory e.g.
+`c:\Program Files\Java\jre1.8.0_201\` whereas `java_path` must be
+set to the absolute path of `java.exe` e.g.
+`c:\Program Files\Java\jre1.8.0_201\bin\java.exe`.
+
+Example usage:
+
+```{.plantuml caption="This is an image, created by **PlantUML**." width=50%}
+@startuml
+Alice -> Bob: Authentication Request Bob --> Alice: Authentication Response
+Alice -> Bob: Another authentication Request Alice <-- Bob: another Response
+@enduml
+```
+
+### Graphviz
+To use Graphviz you only need to install Graphviz, as you can read
+on its [website](http://www.graphviz.org/). There are no other
+dependencies.
+
+This filter assumes that the `dot` command is located in the path
+and therefore can be used from any location. Alternatively, you can
+set the environment variable `DOT` or use the pandoc's meta variable
+`dot_path`.
+
+Example usage from [the Graphviz
+gallery](https://graphviz.gitlab.io/_pages/Gallery/directed/fsm.html):
+
+```{.graphviz caption="This is an image, created by **Graphviz**'s dot."}
+digraph finite_state_machine {
+	rankdir=LR;
+	node [shape = doublecircle]; LR_0 LR_3 LR_4 LR_8;
+	node [shape = circle];
+	LR_0 -> LR_2 [ label = "SS(B)" ];
+	LR_0 -> LR_1 [ label = "SS(S)" ];
+	LR_1 -> LR_3 [ label = "S($end)" ];
+	LR_2 -> LR_6 [ label = "SS(b)" ];
+	LR_2 -> LR_5 [ label = "SS(a)" ];
+	LR_2 -> LR_4 [ label = "S(A)" ];
+	LR_5 -> LR_7 [ label = "S(b)" ];
+	LR_5 -> LR_5 [ label = "S(a)" ];
+	LR_6 -> LR_6 [ label = "S(b)" ];
+	LR_6 -> LR_5 [ label = "S(a)" ];
+	LR_7 -> LR_8 [ label = "S(b)" ];
+	LR_7 -> LR_5 [ label = "S(a)" ];
+	LR_8 -> LR_6 [ label = "S(b)" ];
+	LR_8 -> LR_5 [ label = "S(a)" ];
+}
+```
+
+### Ti*k*Z
+Ti*k*Z (cf. [Wikipedia](https://en.wikipedia.org/wiki/PGF/TikZ)) is a
+description language for graphics of any kind that can be used within
+LaTeX (cf. [Wikipedia](https://en.wikipedia.org/wiki/LaTeX)).
+
+Therefore a LaTeX system must be installed on the system. The Ti*k*Z code is
+embedded into a dynamic LaTeX document. This temporary document gets
+translated into a PDF document using LaTeX (`pdflatex`). Finally,
+Inkscape is used to convert the PDF file to the desired format.
+
+Note: We are using Inkscape here to use a stable solution for the
+convertion. Formerly ImageMagick was used instead. ImageMagick is
+not able to convert PDF files. Hence, it uses Ghostscript to do
+so, cf. [1](https://stackoverflow.com/a/6599718/2258393).
+Unfortunately, Ghostscript behaves unpredictable during Windows and
+Linux tests cases, cf. [2](https://stackoverflow.com/questions/21774561/some-pdfs-are-converted-improperly-using-imagemagick),
+[3](https://stackoverflow.com/questions/9064706/imagemagic-convert-command-pdf-convertion-with-bad-size-orientation), [4](https://stackoverflow.com/questions/18837093/imagemagic-renders-image-with-black-background),
+[5](https://stackoverflow.com/questions/37392798/pdf-to-svg-is-not-perfect),
+[6](https://stackoverflow.com/q/10288065/2258393), etc. By using Inkscape,
+we need one dependency less and get rid of unexpected Ghostscript issues.
+
+Due to this more complicated process, the use of Ti*k*Z is also more
+complicated overall. The process is error-prone: An insufficiently
+configured LaTeX installation or an insufficiently configured
+Inkscape installation can lead to errors. Overall, this results in
+the following dependencies:
+
+- Any LaTeX installation. This should be configured so that
+missing packages are installed automatically. This filter uses the
+`pdflatex` command which is available by the system's path. Alternatively,
+you can set the `PDFLATEX` environment variable. In case you have to use
+a specific LaTeX version on a pandoc document basis, you might set the
+`pdflatex_path` meta variable.
+
+- An installation of [Inkscape](https://inkscape.org/).
+It is assumed that the `inkscape` command is in the path and can be
+executed from any location. Alternatively, the environment
+variable `INKSCAPE` can be set with a path. If a specific
+version per pandoc document is to be used, the `inkscape_path`
+meta-variable can be set.
+
+In order to use additional LaTeX packages, use the optional
+`additionalPackages` attribute in your document, as in the
+example below.
+
+Example usage from [TikZ
+examples](http://www.texample.net/tikz/examples/parallelepiped/) by
+[Kjell Magne Fauske](http://www.texample.net/tikz/examples/nav1d/):
+
+```{.tikz caption="This is an image, created by **TikZ i.e. LaTeX**."
+     additionalPackages="\usepackage{adjustbox}"}
+\usetikzlibrary{arrows}
+\tikzstyle{int}=[draw, fill=blue!20, minimum size=2em]
+\tikzstyle{init} = [pin edge={to-,thin,black}]
+
+\resizebox{16cm}{!}{%
+  \trimbox{3.5cm 0cm 0cm 0cm}{
+    \begin{tikzpicture}[node distance=2.5cm,auto,>=latex']
+      \node [int, pin={[init]above:$v_0$}] (a) {$\frac{1}{s}$};
+      \node (b) [left of=a,node distance=2cm, coordinate] {a};
+      \node [int, pin={[init]above:$p_0$}] at (0,0) (c)
+        [right of=a] {$\frac{1}{s}$};
+      \node [coordinate] (end) [right of=c, node distance=2cm]{};
+      \path[->] (b) edge node {$a$} (a);
+      \path[->] (a) edge node {$v$} (c);
+      \draw[->] (c) edge node {$p$} (end) ;
+    \end{tikzpicture}
+  }
+}
+```
+
+### Python
+In order to use Python to generate an diagram, your Python code must store the
+final image data in a temporary file with the correct format. In case you use
+matplotlib for a diagram, add the following line to do so:
+
+```python
+plt.savefig("$DESTINATION$", dpi=300, format="$FORMAT$")
+```
+
+The placeholder `$FORMAT$` gets replace by the necessary format. Most of the
+time, this will be `png` or `svg`. The second placeholder, `$DESTINATION$`
+gets replaced by the path and file name of the destination. Both placeholders
+can be used as many times as you want. Example usage from the [Matplotlib
+examples](https://matplotlib.org/gallery/lines_bars_and_markers/cohere.html#sphx-glr-gallery-lines-bars-and-markers-cohere-py):
+
+```{.py2image caption="This is an image, created by **Python**."}
+import matplotlib
+matplotlib.use('Agg')
+
+import sys
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Fixing random state for reproducibility
+np.random.seed(19680801)
+
+dt = 0.01
+t = np.arange(0, 30, dt)
+nse1 = np.random.randn(len(t))                 # white noise 1
+nse2 = np.random.randn(len(t))                 # white noise 2
+
+# Two signals with a coherent part at 10Hz and a random part
+s1 = np.sin(2 * np.pi * 10 * t) + nse1
+s2 = np.sin(2 * np.pi * 10 * t) + nse2
+
+fig, axs = plt.subplots(2, 1)
+axs[0].plot(t, s1, t, s2)
+axs[0].set_xlim(0, 2)
+axs[0].set_xlabel('time')
+axs[0].set_ylabel('s1 and s2')
+axs[0].grid(True)
+
+cxy, f = axs[1].cohere(s1, s2, 256, 1. / dt)
+axs[1].set_ylabel('coherence')
+
+fig.tight_layout()
+plt.savefig("$DESTINATION$", dpi=300, format="$FORMAT$")
+```
+
+Precondition to use Python is a Python environment which contains all
+necessary libraries you want to use. To use, for example, the standard
+[Anaconda Python](https://www.anaconda.com/distribution/) environment
+on a Microsoft Windows system ...
+
+- set the environment variable `PYTHON` or the meta key `pythonPath`
+to `c:\ProgramData\Anaconda3\python.exe`
+
+- set the environment variable `PYTHON_ACTIVATE` or the meta
+key `activate_python_path` to `c:\ProgramData\Anaconda3\Scripts\activate.bat`.
+
+Pandoc will activate this Python environment and starts Python with your code.
+
+## Asymptote
+[Asymptote](https://asymptote.sourceforge.io/) is a graphics
+language inspired by Metapost. To use Asymptote, you will need to
+install the software itself, a TeX distribution such as
+[TeX Live](https://www.tug.org/texlive/), and
+[dvisvgm](https://dvisvgm.de/), which may be included in the TeX
+distribution.
+
+If png output is required (such as for the `docx`, `pptx` and `rtf`
+output formats) Inkscape must be installed. See the Ti*k*Z section
+for details.
+
+Ensure that the Asymptote `asy` binary is in the path, or point
+the environment variable `ASYMPTOTE` or the metadata variable
+`asymptotePath` to the full path name. Asymptote calls the various
+TeX utilities and dvipdfm, so you will need to configure Asymptote
+so that it finds them.
+
+```{.asymptote caption="This is an image, created by **Asymptote**."}
+size(5cm);
+include graph;
+
+pair circumcenter(pair A, pair B, pair C)
+{
+  pair P, Q, R, S;
+  P = (A+B)/2;
+  Q = (B+C)/2;
+  R = rotate(90, P) * A;
+  S = rotate(90, Q) * B;
+  return extension(P, R, Q, S);
+}
+
+pair incenter(pair A, pair B, pair C)
+{
+  real a = abs(angle(C-A)-angle(B-A)),
+       b = abs(angle(C-B)-angle(A-B)),
+       c = abs(angle(A-C)-angle(B-C));
+  return (sin(a)*A + sin(b)*B + sin(c)*C) / (sin(a)+sin(b)+sin(c));
+}
+
+real dist_A_BC(pair A, pair B, pair C)
+{
+  real det = cross(B-A, C-A);
+  return abs(det/abs(B-C));
+}
+
+pair A = (0, 0), B = (5, 0), C = (3.5, 4),
+     O = circumcenter(A, B, C),
+     I = incenter(A, B, C);
+dot(A); dot(B); dot(C); dot(O, blue); dot(I, magenta);
+draw(A--B--C--cycle, linewidth(2));
+draw(Circle(O, abs(A-O)), blue+linewidth(1.5));
+draw(Circle(I, dist_A_BC(I, A, B)), magenta+linewidth(1.5));
+label("$A$", A, SW);
+label("$B$", B, SE);
+label("$C$", C, NE);
+label("$O$", O, W);
+label("$I$", I, E);
+```
+
+## How to run pandoc
+This section will show, how to call Pandoc in order to use this filter with
+meta keys. The following command assume, that the filters are stored in the
+subdirectory `filters`. Further, this is a example for a Microsoft Windows
+system.
+
+Command to use PlantUML (a single line):
+
+```
+pandoc.exe README.md -f markdown -t docx --self-contained --standalone --lua-filter=filters\diagram-generator.lua --metadata=plantumlPath:"c:\ProgramData\chocolatey\lib\plantuml\tools\plantuml.jar" --metadata=javaPath:"c:\Program Files\Java\jre1.8.0_201\bin\java.exe" -o README.docx
+```
+
+All available environment variables:
+
+- `PLANTUML` e.g. `c:\ProgramData\chocolatey\lib\plantuml\tools\plantuml.jar`; Default: `plantuml.jar`
+- `INKSCAPE` e.g. `c:\Program Files\Inkscape\inkscape.exe`; Default: `inkscape`
+- `PYTHON` e.g. `c:\ProgramData\Anaconda3\python.exe`; Default: n/a
+- `PYTHON_ACTIVATE` e.g. `c:\ProgramData\Anaconda3\Scripts\activate.bat`; Default: n/a
+- `JAVA_HOME` e.g. `c:\Program Files\Java\jre1.8.0_201`; Default: n/a
+- `DOT` e.g. `c:\ProgramData\chocolatey\bin\dot.exe`; Default: `dot`
+- `PDFLATEX` e.g. `c:\Program Files\MiKTeX 2.9\miktex\bin\x64\pdflatex.exe`; Default: `pdflatex`
+- `ASYMPTOTE` e.g. `c:\Program Files\Asymptote\asy`; Default: `asy`
+
+All available meta keys:
+
+- `plantuml_path`
+- `inkscape_path`
+- `python_path`
+- `activate_python_path`
+- `java_path`
+- `dot_path`
+- `pdflatex_path`
+- `asymptote_path`


### PR DESCRIPTION
Fix: https://github.com/openjournals/joss/issues/1281
Builds on: 
- https://github.com/openjournals/inara/pull/45
- https://github.com/openjournals/inara/pull/46

Add support for graphviz and mermaid diagrams using https://github.com/pandoc-ext/diagram

- Vendored lua plugin bc no clean way to include it otherwise and i hate using submodules
- symlinked to filters directory
- added to default filters
- configured to enable/diable diagram engines consistent with security recs in source repo
- added deps to dockerfile
- wrote examples in `example/paper.md`

Works in the `tex`, `html`, and `jats` formats

eg. PDF:

<img width="626" alt="Screenshot 2024-02-28 at 9 05 36 PM" src="https://github.com/openjournals/inara/assets/12961499/1cde0070-ab75-4786-a637-3201dbe18216">
<img width="631" alt="Screenshot 2024-02-28 at 9 05 49 PM" src="https://github.com/openjournals/inara/assets/12961499/6565d544-2c2a-4d48-ba15-835dbcc93571">

Also added an example of how to include a highlighted code block because i thought it was weird we didn't have one

(Again sorry for non-modular PR, couldn't get the code to run otherwise)