### PR TITLE
Delete duplicate key in contextpdf.yaml

### DIFF
--- a/data/defaults/contextpdf.yaml
+++ b/data/defaults/contextpdf.yaml
@@ -72,7 +72,6 @@ variables:
     - location={footer,margin}
     - state=start
 
-  papersize: a4
   pdfa: 3a
   whitespace: none
   # Use the international standard


### PR DESCRIPTION
`papersize: a4` appears twice in `contextpdf.yaml`. This PR removes the one that isn't group with other layout information