### PR TITLE
Fix affiliation bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 `Inara` uses [SemVer][] (semantic versioning).
 
+## Inara v1.1.1
+
+- Fix bug in application of `prepare-affiliations.lua` filter (Charles Tapley Hoyt)
+
 ## Inara v1.1.0
 
 Released 2024-09-04.

--- a/data/defaults/pdf.yaml
+++ b/data/defaults/pdf.yaml
@@ -11,6 +11,8 @@ filters:
     path: self-citation.lua
   - type: lua
     path: fix-bibentry-spacing.lua
+  - type: lua
+    path: prepare-affiliations.lua
 variables:
   # styling options
   colorlinks: true

--- a/data/defaults/preprint.yaml
+++ b/data/defaults/preprint.yaml
@@ -1,6 +1,9 @@
 to: latex
 output-file: paper.preprint.tex
 template: preprint.latex
+filters:
+  - type: lua
+    path: prepare-affiliations.lua
 variables:
   # styling options
   colorlinks: true

--- a/data/filters/prepare-affiliations.lua
+++ b/data/filters/prepare-affiliations.lua
@@ -7,9 +7,9 @@ function Meta (meta)
   -- and meta.author (the processed one)
   for _, author in ipairs(meta.authors or {}) do
     local xml = "<affiliations>"
-    for i, affiliation_list in ipairs(author.affiliation) do
-        local index = tonumber(affiliation_list[1].text)
-        local affiliation = meta.affiliations[index]
+    for i, affiliation_index in ipairs(author.affiliation) do
+        affiliation_index = tonumber(pandoc.utils.stringify(affiliation_index))
+        local affiliation = meta.affiliations[affiliation_index]
         xml = xml.. "\n  <institution><institution_name>"
         for _, v in ipairs(affiliation.name) do
           if v.text then

--- a/example/paper.md
+++ b/example/paper.md
@@ -4,7 +4,7 @@ title: >-
 authors:
   - name: Albert Krewinkel
     email: albert@zeitkraut.de
-    affiliation: [1, 2, 4]
+    affiliation: "1, 2, 4"
     orcid: 0000-0002-9455-0796
     corresponding: true
   - name: Juanjo Bazán


### PR DESCRIPTION
There were two issues in the `prepare-affiliatons.lua` script

1. Somehow during the squash/merge process, the part where it got applied in the `pdf` and `preprint` configurations got lost...
2. This PR makes it more robust for string format for affiliation lists, and adds into the example PDF an example where affiliations are given in a string list