### PR TITLE
Final improvements to make tests pass on GitHub CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,12 @@ example/paper.tex
 /test/JATS-journalpublishing1-elements.xsd
 /test/JATS-journalpublishing1.xsd
 /test/standard-modules
+
+# If you copy the resources into the base directory to
+# make the Makefile work, don't accidentally commit these
+apa.csl
+default-article-info.yaml
+footer.csl
+/joss
+/jose
+/resciencec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ## Inara v1.1.2
 
 - Fix bug in application of `prepare-affiliations.lua` filter (Charles Tapley Hoyt)
+- Fix a bug in the injection of `SOURCE_DATE_EPOCH` (https://github.com/openjournals/inara/pull/86) in tests
+- Fix test files (https://github.com/openjournals/inara/pull/86, https://github.com/openjournals/inara/pull/85)
+- Switch testing to work on tex instead of pdf (https://github.com/openjournals/inara/pull/82)
+- Refactor testing folders (https://github.com/openjournals/inara/pull/84)
 
 ## Inara v1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 `Inara` uses [SemVer][] (semantic versioning).
 
-## Inara v1.1.2
+## UNRELEASED
 
 - Fix bug in application of `prepare-affiliations.lua` filter (Charles Tapley Hoyt)
 - Fix a bug in the injection of `SOURCE_DATE_EPOCH` (https://github.com/openjournals/inara/pull/86) in tests

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,9 @@ clean:
 
 ## Tests
 
+# Note that SOURCE_DATE_EPOCH=1234567890 corresponds to 1234567890 seconds
+# from the unix epoch (January 1, 1970), which is in 2009
+
 # Command used to invoke Inara. Sets an environment variable that makes the
 # program ignore the real date.
 INARA_TEST_CMD = docker run --rm \

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ ARTICLE_INFO_FILE = $(OPENJOURNALS_PATH)/default-article-info.yaml
 
 IMAGE = openjournals/inara:edge
 
+MAKEFILE_DIR := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
+
 .PHONY: all
 all: cff pdf tex html jats crossref native preprint
 
@@ -98,6 +100,10 @@ INARA_TEST_CMD = docker run --rm \
 	--user $(shell id -u):$(shell id -g) \
 	--env SOURCE_DATE_EPOCH=1234567890 \
 	-v $${PWD}:/data $(IMAGE)
+
+# Uncomment this if you want to run tests locally instead of inside docker,
+# though note that there might be non-trivial differences that are hard to explain
+# INARA_TEST_CMD = SOURCE_DATE_EPOCH=1234567890 JOURNAL=joss OPENJOURNALS_PATH=$(MAKEFILE_DIR) sh scripts/entrypoint.sh
 
 .PHONY: test test-golden-draft test-golden-pub
 test: test-golden-draft test-golden-pub

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,10 @@ INARA_TEST_CMD = docker run --rm \
 	-v $${PWD}:/data $(IMAGE)
 
 # Uncomment this if you want to run tests locally instead of inside docker,
-# though note that there might be non-trivial differences that are hard to explain
+# though note that there might be non-trivial differences that are hard to explain.
+# You also have to run `cp -r resources/* .` to copy all of the resource files
+# into the root directory, since this makefile relies on this directory structure
+# which the dockerfile creates
 # INARA_TEST_CMD = SOURCE_DATE_EPOCH=1234567890 JOURNAL=joss OPENJOURNALS_PATH=$(MAKEFILE_DIR) sh scripts/entrypoint.sh
 
 .PHONY: test test-golden-draft test-golden-pub

--- a/data/filters/draft.lua
+++ b/data/filters/draft.lua
@@ -4,11 +4,15 @@
 --- resources/default-article-info.yaml
 function Meta (meta)
   if meta.draft and meta.draft ~= '' then
+    local epoch = os.getenv 'SOURCE_DATE_EPOCH'
+      and os.time { year = 1970, month = 1, day = 1, hour = 0, min = 0,
+                  sec = tonumber(os.getenv 'SOURCE_DATE_EPOCH') }
+      or os.time()
     meta.article.doi = '10.xxxxxx/draft'
     meta.article.issue = '¿ISSUE?'
     meta.article.volume = '¿VOL?'
     meta.published = 'unpublished'
-    meta.published_parts = os.date('*t')
+    meta.published_parts = os.date('*t', epoch)
     return meta
   end
 end

--- a/data/filters/draft.lua
+++ b/data/filters/draft.lua
@@ -4,14 +4,11 @@
 --- resources/default-article-info.yaml
 function Meta (meta)
   if meta.draft and meta.draft ~= '' then
-    meta.cthdraft = true
     meta.article.doi = '10.xxxxxx/draft'
     meta.article.issue = '¿ISSUE?'
     meta.article.volume = '¿VOL?'
     meta.published = 'unpublished'
     meta.published_parts = os.date('*t')
     return meta
-  else
-    meta.cthdraft = false
   end
 end

--- a/data/filters/draft.lua
+++ b/data/filters/draft.lua
@@ -1,11 +1,17 @@
 --- Removes and alters metadata for draft output
+
+--- If you change this, please keep it in sync with
+--- resources/default-article-info.yaml
 function Meta (meta)
   if meta.draft and meta.draft ~= '' then
+    meta.cthdraft = true
     meta.article.doi = '10.xxxxxx/draft'
-    meta.article.issue = '0'
-    meta.article.volume = '0'
+    meta.article.issue = '¿ISSUE?'
+    meta.article.volume = '¿VOL?'
     meta.published = 'unpublished'
     meta.published_parts = os.date('*t')
     return meta
+  else
+    meta.cthdraft = false
   end
 end

--- a/resources/default-article-info.yaml
+++ b/resources/default-article-info.yaml
@@ -1,3 +1,6 @@
+# If you change this, please keep it in sync with
+# data/filters/draft.lua
+
 metadata:
   archive_doi: 'DOI unavailable'
   editor_url: 'https://example.com'

--- a/resources/default-article-info.yaml
+++ b/resources/default-article-info.yaml
@@ -7,7 +7,7 @@ metadata:
   editor_name: 'Pending Editor'
   issue: '¿ISSUE?'
   page: '¿PAGE?'
-  published_at: '1970-01-01'
+  published_at: 'unpublished'
   reviewers:
     - 'Pending Reviewers'
   submitted_at: '1970-01-01'

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -111,8 +111,9 @@ for format in $(printf "%s" "$outformats" | sed -e 's/,/ /g'); do
     #    inara git repo that is created in Docker, in which the contents of
     #    the resources/ directory is copied into the root directory
     # 3. assumes pandoc is in a certain location. Switch `/usr/local/bin/pandoc`
-    #    to just `pandoc` locally
     /usr/local/bin/pandoc \
+    #    to just `pandoc` locally, or symlink with
+    #    sudo ln -s $which(pandoc) /usr/local/bin/pandoc
 	      --data-dir="$OPENJOURNALS_PATH"/data \
         --defaults=shared \
         --defaults="${format}" \

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -111,9 +111,9 @@ for format in $(printf "%s" "$outformats" | sed -e 's/,/ /g'); do
     #    inara git repo that is created in Docker, in which the contents of
     #    the resources/ directory is copied into the root directory
     # 3. assumes pandoc is in a certain location. Switch `/usr/local/bin/pandoc`
-    /usr/local/bin/pandoc \
     #    to just `pandoc` locally, or symlink with
     #    sudo ln -s $which(pandoc) /usr/local/bin/pandoc
+    /usr/local/bin/pandoc \
 	      --data-dir="$OPENJOURNALS_PATH"/data \
         --defaults=shared \
         --defaults="${format}" \

--- a/test/expected-draft/paper.tex
+++ b/test/expected-draft/paper.tex
@@ -136,7 +136,7 @@ Arfon M. Smith},
 \renewcommand{\footrulewidth}{0.25pt}
 
 \fancyfoot[L]{\parbox[t]{0.98\headwidth}{\footnotesize{\sffamily Krewinkel
-et al. (2024). Article Writing with Markdown and the Open Journals
+et al. (2009). Article Writing with Markdown and the Open Journals
 publishing pipeline. \emph{Journal of Open Source Software},
 \emph{¿VOL?}(¿ISSUE?), ¿PAGE? \url{https://doi.org/10.xxxxxx/draft}}.}}
 

--- a/test/expected-draft/paper.tex
+++ b/test/expected-draft/paper.tex
@@ -21,7 +21,7 @@ publishing pipeline},
     pdfpubtype={journal},
     pdfvolumenum={},
     pdfissuenum={},
-    pdfdoi={N/A},
+    pdfdoi={10.xxxxxx/draft},
     pdfcopyright={Copyright (c) 1970, Albert Krewinkel, Juanjo Bazán,
 Arfon M. Smith},
     pdflicenseurl={http://creativecommons.org/licenses/by/4.0/},
@@ -136,9 +136,9 @@ Arfon M. Smith},
 \renewcommand{\footrulewidth}{0.25pt}
 
 \fancyfoot[L]{\parbox[t]{0.98\headwidth}{\footnotesize{\sffamily Krewinkel
-et al. (1970). Article Writing with Markdown and the Open Journals
+et al. (2024). Article Writing with Markdown and the Open Journals
 publishing pipeline. \emph{Journal of Open Source Software},
-\emph{¿VOL?}(¿ISSUE?), ¿PAGE? \url{https://doi.org/N/A}}.}}
+\emph{0}(0), ¿PAGE? \url{https://doi.org/10.xxxxxx/draft}}.}}
 
 
 \fancyfoot[R]{\sffamily \thepage}
@@ -316,6 +316,9 @@ publishing pipeline. \emph{Journal of Open Source Software},
 \newcommand{\VerbatimStringTok}[1]{\textcolor[rgb]{0.25,0.44,0.63}{#1}}
 \newcommand{\WarningTok}[1]{\textcolor[rgb]{0.38,0.63,0.69}{\textbf{\textit{#1}}}}
 \usepackage{longtable,booktabs,array}
+\usepackage{lineno}
+\linenumbers
+\usepackage{draftwatermark}
 
 \usepackage{graphicx,grffile}
 \makeatletter
@@ -394,7 +397,7 @@ pipeline}
   %\hrule
   \sffamily\small
 
-  {\bfseries DOI:} \href{https://doi.org/N/A}{\color{linky}{N/A}}
+  {\bfseries DOI:} \href{https://doi.org/10.xxxxxx/draft}{\color{linky}{10.xxxxxx/draft}}
 
   \vspace{2mm}
     {\bfseries Software}
@@ -423,7 +426,7 @@ Journals} \ExternalLink
     \vspace{2mm}
   
     {\bfseries Submitted:} 01 January 1970\\
-    {\bfseries Published:} 01 January 1970
+    {\bfseries Published:} unpublished
 
   \vspace{2mm}
   {\bfseries License}\\

--- a/test/expected-draft/paper.tex
+++ b/test/expected-draft/paper.tex
@@ -138,7 +138,7 @@ Arfon M. Smith},
 \fancyfoot[L]{\parbox[t]{0.98\headwidth}{\footnotesize{\sffamily Krewinkel
 et al. (2024). Article Writing with Markdown and the Open Journals
 publishing pipeline. \emph{Journal of Open Source Software},
-\emph{0}(0), ¿PAGE? \url{https://doi.org/10.xxxxxx/draft}}.}}
+\emph{¿VOL?}(¿ISSUE?), ¿PAGE? \url{https://doi.org/10.xxxxxx/draft}}.}}
 
 
 \fancyfoot[R]{\sffamily \thepage}


### PR DESCRIPTION
This is the last PR that finally makes the unit tests work. This PR also adds several other notes to help future contributors understand the workflow, and get it running locally.


<details>
<summary>Details on an issue we solved during this PR related to SOURCE_DATE_EPOCH</summary>

The `expected-draft/paper.tex` which outputs the current year. This gets there because of the following code:

1. https://github.com/openjournals/inara/blob/c430b5b84ec3f7aefaae21b624bda3cefdca66fe/data/templates/default.latex#L155
2. `self-citations` is added in https://github.com/openjournals/inara/blob/c430b5b84ec3f7aefaae21b624bda3cefdca66fe/data/filters/self-citation.lua#L33
3. which gets set in https://github.com/openjournals/inara/blob/c430b5b84ec3f7aefaae21b624bda3cefdca66fe/data/filters/draft.lua#L8
4. which comes from https://github.com/openjournals/inara/blob/c430b5b84ec3f7aefaae21b624bda3cefdca66fe/data/filters/time.lua#L28
5. which in theory, is modulated by setting the `SOURCE_DATE_EPOCH` in https://github.com/openjournals/inara/blob/c430b5b84ec3f7aefaae21b624bda3cefdca66fe/Makefile#L97-L100

I think it's probably a fair compromise to remind ourselves once per year to update this rather than hacking more conditionals in there (at least on this pass)

</details>