### PR TITLE
Add contributor roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 `Inara` uses [SemVer][] (semantic versioning).
 
+## UNRELEASED
+
+- Support for annotating contributor roles with the Contribution Role Taxonomy (CRediT).
+  A text table is generated at the bottom of the PDF and preprint template containing
+  this information. As of https://github.com/jgm/pandoc/pull/10153, Pandoc will generate
+  conformant JATS containing contributor roles. (https://github.com/openjournals/inara/pull/87)
+
 ## Inara v1.3.0
 
 Released 2026-01-18.

--- a/data/defaults/jats.yaml
+++ b/data/defaults/jats.yaml
@@ -18,3 +18,6 @@ filters:
     # do it here for that reason.
     type: lua
     path: orcid-uri.lua
+
+  - type: lua
+    path: prepare-credit.lua

--- a/data/defaults/pdf.yaml
+++ b/data/defaults/pdf.yaml
@@ -11,6 +11,8 @@ filters:
     path: self-citation.lua
   - type: lua
     path: fix-bibentry-spacing.lua
+  - type: lua
+    path: prepare-credit.lua
 variables:
   # styling options
   colorlinks: true

--- a/data/defaults/preprint.yaml
+++ b/data/defaults/preprint.yaml
@@ -1,6 +1,9 @@
 to: latex
 output-file: paper.preprint.tex
 template: preprint.latex
+filters:
+  - type: lua
+    path: prepare-credit.lua
 variables:
   # styling options
   colorlinks: true

--- a/data/defaults/tex.yaml
+++ b/data/defaults/tex.yaml
@@ -11,6 +11,8 @@ filters:
     path: self-citation.lua
   - type: lua
     path: fix-bibentry-spacing.lua
+  - type: lua
+    path: prepare-credit.lua
 variables:
   # styling options
   colorlinks: true

--- a/data/filters/prepare-credit.lua
+++ b/data/filters/prepare-credit.lua
@@ -1,0 +1,227 @@
+-- Checks if any contributor information is available
+
+local roles = {
+    ["conceptualization"] = {
+        name = "Conceptualization",
+        id = "8b73531f-db56-4914-9502-4cc4d4d8ed73",
+        uri = "https://credit.niso.org/contributor-roles/conceptualization/"
+    },
+    ["data-curation"] = {
+        name = "Data curation",
+        id = "f93e0f44-f2a4-4ea1-824a-4e0853b05c9d",
+        uri = "https://credit.niso.org/contributor-roles/data-curation/"
+    },
+    ["formal-analysis"] = {
+        name = "Formal analysis",
+        id = "95394cbd-4dc8-4735-b589-7e5f9e622b3f",
+        uri = "https://credit.niso.org/contributor-roles/formal-analysis/"
+    },
+    ["funding-acquisition"] = {
+        name = "Funding acquisition",
+        id = "34ff6d68-132f-4438-a1f4-fba61ccf364a",
+        uri = "https://credit.niso.org/contributor-roles/funding-acquisition/"
+    },
+    ["investigation"] = {
+        name = "Investigation",
+        id = "2451924d-425e-4778-9f4c-36c848ca70c2",
+        uri = "https://credit.niso.org/contributor-roles/investigation/"
+    },
+    ["methodology"] = {
+        name = "Methodology",
+        id = "f21e2be9-4e38-4ab7-8691-d6f72d5d5843",
+        uri = "https://credit.niso.org/contributor-roles/methodology/"
+    },
+    ["project-administration"] = {
+        name = "Project administration",
+        id = "a693fe76-ea33-49ad-9dcc-5e4f3ac5f938",
+        uri = "https://credit.niso.org/contributor-roles/project-administration/"
+    },
+    ["resources"] = {
+        name = "Resources",
+        id = "ebd781f0-bf79-492c-ac21-b31b9c3c990c",
+        uri = "https://credit.niso.org/contributor-roles/resources/"
+    },
+    ["software"] = {
+        name = "Software",
+        id = "f89c5233-01b0-4778-93e9-cc7d107aa2c8",
+        uri = "https://credit.niso.org/contributor-roles/software/"
+    },
+    ["supervision"] = {
+        name = "Supervision",
+        id = "0c8ca7d4-06ad-4527-9cea-a8801fcb8746",
+        uri = "https://credit.niso.org/contributor-roles/supervision/"
+    },
+    ["validation"] = {
+        name = "Validation",
+        id = "4b1bf348-faf2-4fc4-bd66-4cd3a84b9d44",
+        uri = "https://credit.niso.org/contributor-roles/validation/"
+    },
+    ["visualization"] = {
+        name = "Visualization",
+        id = "76b9d56a-e430-4e0a-84c9-59c11be343ae",
+        uri = "https://credit.niso.org/contributor-roles/visualization/"
+    },
+    ["writing-original-draft"] = {
+        name = "Writing – original draft",
+        id = "43ebbd94-98b4-42f1-866b-c930cef228ca",
+        uri = "https://credit.niso.org/contributor-roles/writing-original-draft/"
+    },
+    ["writing-review-editing"] = {
+        name = "Writing – review & editing",
+        id = "d3aead86-f2a2-47f7-bb99-79de6421164d",
+        uri = "https://credit.niso.org/contributor-roles/writing-review-editing/"
+    }
+}
+
+-- An enumeration of the JATS-recommended degrees of contribution
+degrees = pandoc.List {
+    "Lead",
+    "Supporting",
+    "Equal"
+}
+
+-- Check if the given string is one of the 14 valid
+-- CRediT identifiers by looking at the `roles` dict
+-- defined above
+function invalidCreditID(str)
+    return roles[str] == nil
+end
+
+-- Check if the degree contribution is valid based on the JATS recommendation,
+-- see https://jats.taylorandfrancis.com/jats-guide/topics/author-contributions-credit/#degree-of-contribution
+function invalidDegree(str)
+    return not degrees:includes(str)
+end
+
+function join_with_commas_and(list)
+    local len = #list
+    if len == 0 then
+        return ""
+    elseif len == 1 then
+        return list[1]
+    elseif len == 2 then
+        return list[1] .. " & " .. list[2]
+    else
+        local result = table.concat(list, ", ", 1, len - 1)
+        return result .. ", & " .. list[len]
+    end
+end
+
+function capitalize_first_letter(str)
+    return str:sub(1, 1):upper() .. str:sub(2)
+end
+
+-- If the data is just a string corresponding to a
+-- CRediT identifier, upgrade it to a dictionary,
+-- otherwise return it as is
+function clean_role_dict(d)
+    if d.credit then
+        return d
+    else
+        return { ["credit"] = pandoc.utils.stringify(d) }
+    end
+end
+
+local function prepare_credit (meta)
+    meta.hasRoles = false
+    for _, author in ipairs(meta.authors or {}) do
+        if author.roles then
+            roleList = {}
+            for _, roleDict in ipairs(author.roles) do
+                roleDict = clean_role_dict(roleDict)
+                credit_id = pandoc.utils.stringify(roleDict.credit)
+                if invalidCreditID(credit_id) then
+                    print("invalid credit ID for author " .. author.name .. ": " .. credit_id)
+                elseif roleDict.degree then
+                    degree = capitalize_first_letter(pandoc.utils.stringify(roleDict.degree))
+                    if invalidDegree(degree) then
+                        print("invalid degree for author " .. author.name .. ": " .. degree)
+                        -- even though the degree is invalid, add the role anyway
+                        table.insert(roleList, roles[credit_id].name)
+                    else
+                        table.insert(roleList, roles[credit_id].name .. " (" .. degree .. ")")
+                    end
+                else
+                    table.insert(roleList, roles[credit_id].name)
+                end
+            end
+            if #roleList > 0 then
+                meta.hasRoles = true
+                author.rolesString = join_with_commas_and(roleList)
+            end
+        end
+    end
+    return meta
+end
+
+function Meta (meta)
+    local ok, result = pcall(prepare_credit, meta)
+    if ok then
+        return result
+    end
+end
+
+function assertEqual(expected, actual)
+    assert(expected == actual, "got \"" .. actual .. "\", expected \"" .. expected .. "\"")
+end
+
+function tests()
+    assert("" == join_with_commas_and({ }))
+    assert("foo" == join_with_commas_and({ "foo" }))
+    assert("foo & bar" == join_with_commas_and({ "foo", "bar" }))
+    assert("foo, bar, & baz" == join_with_commas_and({ "foo", "bar", "baz" }))
+
+    local m1 = {
+        ["authors"] = {
+            {
+                ["name"] = "Author 1",
+                ["roles"] = {
+                    "methodology"
+                }
+            },
+            {
+                ["name"] = "Author 2",
+                ['roles'] = {
+                    { ["credit"] = "methodology" }
+                }
+            },
+            {
+                ["name"] = "Author 3",
+                ['roles'] = {
+                    { ["credit"] = "methodology" },
+                    { ["credit"] = "data-curation" },
+                    { ["credit"] = "conceptualization" },
+                }
+            },
+            {
+                ["name"] = "Author 4",
+                ['roles'] = {
+                    { ["credit"] = "methodology", ["degree"] = "lead" },
+                    { ["credit"] = "data-curation", ["degree"] = "supporting" },
+                    { ["credit"] = "conceptualization" },
+                }
+            },
+        }
+    }
+    local m1t = prepare_credit(m1)
+    assert(m1t.hasRoles, "hasRoles should be set to true")
+    assertEqual("Methodology", m1t['authors'][1].rolesString)
+    assertEqual("Methodology", m1t['authors'][2].rolesString)
+    assertEqual("Methodology, Data curation, & Conceptualization", m1t['authors'][3].rolesString)
+    assertEqual("Methodology (Lead), Data curation (Supporting), & Conceptualization", m1t['authors'][4].rolesString)
+
+    local m2 = {
+        ["authors"] = {
+            {
+                ["name"] = "Author 1"
+            },
+            {
+                ["name"] = "Author 2"
+            }
+        }
+    }
+    local m2t = prepare_credit(m2)
+    assert(not m2t.hasRoles, "hasRoles should be set to false")
+end
+
+tests()

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -396,6 +396,17 @@ $if(lof)$
 $endif$
 $body$
 
+$if(hasRoles)$
+\section{Author Contributions}\label{author-contributions}
+\begin{enumerate}
+$for(authors)$
+$if(it.rolesString)$
+\item $it.name$ - $it.rolesString$
+$endif$
+$endfor$
+\end{enumerate}
+$endif$
+
 $if(natbib)$
 $if(bibliography)$
 $if(biblio-title)$

--- a/data/templates/preprint.latex
+++ b/data/templates/preprint.latex
@@ -435,6 +435,17 @@ $if(has-frontmatter)$
 $endif$
 $body$
 
+$if(hasRoles)$
+\section{Author Contributions}\label{author-contributions}
+\begin{enumerate}
+$for(authors)$
+$if(it.rolesString)$
+\item $it.name$ - $it.rolesString$
+$endif$
+$endfor$
+\end{enumerate}
+$endif$
+
 $if(has-frontmatter)$
 \backmatter
 $endif$

--- a/example/paper.md
+++ b/example/paper.md
@@ -7,14 +7,27 @@ authors:
     affiliation: "1, 2, 4"
     orcid: 0000-0002-9455-0796
     corresponding: true
+    roles:
+      - credit: software
+        degree: equal
+      - 'methodology'
   - name: Juanjo Bazán
     orcid: 0000-0001-7699-3983
     affiliation: [1]
     equal-contrib: true
+    roles:
+      - credit: software
+        degree: equal
   - name: Arfon M. Smith
     orcid: 0000-0002-3957-2474
     affiliation: [1, 3]
     equal-contrib: true
+    roles:
+      - credit: software
+        degree: equal
+      - credit: supervision
+        degree: lead
+
 affiliations:
   - index: 1
     name: Open Journals
@@ -364,6 +377,72 @@ authors:
   <!--     literal: 立花 瀧 -->
   <!--     given-names: 瀧 -->
   <!--     surname: 立花 -->
+
+## Contributor Roles
+
+The [Contribution Role Taxonomy (CRediT)](https://credit.niso.org/contributor-roles) defines
+fourteen standard roles of authors. Each author can be annotated with one or more contribution
+roles.
+
+1. [conceptualization](https://credit.niso.org/contributor-roles/conceptualization)
+2. [data-curation](https://credit.niso.org/contributor-roles/data-curation)
+3. [formal-analysis](https://credit.niso.org/contributor-roles/formal-analysis)
+4. [funding-acquisition](https://credit.niso.org/contributor-roles/funding-acquisition)
+5. [investigation](https://credit.niso.org/contributor-roles/investigation)
+6. [methodology](https://credit.niso.org/contributor-roles/methodology)
+7. [project-administration](https://credit.niso.org/contributor-roles/project-administration)
+8. [resources](https://credit.niso.org/contributor-roles/resources)
+9. [software](https://credit.niso.org/contributor-roles/software)
+10. [supervision](https://credit.niso.org/contributor-roles/supervision)
+11. [validation](https://credit.niso.org/contributor-roles/validation)
+12. [visualization](https://credit.niso.org/contributor-roles/visualization)
+13. [writing-original-draft](https://credit.niso.org/contributor-roles/writing-original-draft)
+14. [writing-review-editing](https://credit.niso.org/contributor-roles/writing-review-editing)
+
+JATS also specifies three degrees which can be used to quantify the impact of a contribution:
+
+1. `Lead`
+2. `Supporting`
+3. `Equal` - for use if multiple equivalent leads
+
+Together, these can be used to identify which authors materially contributed to the paper,
+such as through `formal-analysis` or `data-curation` and which authors contributed immaterially,
+such as through `supervision`. It also allows for saying if multiple people made the same
+kind of contribution, who took the lead.
+
+```yaml
+authors:
+  - name: John Doe
+    affiliation: [ 1 ]
+    roles:
+      - credit: 'formal-analysis'
+        degree: 'lead'
+
+  - name: John Boss
+    affiliation: [ 1 ]
+    roles:
+      - credit: 'funding-acquisition'
+        degree: 'lead'
+      - credit: 'supervision'
+        degree: 'lead'
+```
+
+Roles are optional, and within roles, degrees are optional. It's possible to shorthand
+roles by using strings directly:
+
+```yaml
+authors:
+  - name: John Doe
+    affiliation: [ 1 ]
+    roles:
+      - 'formal-analysis'
+
+  - name: John Boss
+    affiliation: [ 1 ]
+    roles:
+      - 'funding-acquisition'
+      - 'supervision'
+```
 
 ## Affiliations
 

--- a/test/expected-draft/paper.jats/paper.jats
+++ b/test/expected-draft/paper.jats/paper.jats
@@ -28,6 +28,16 @@ publishing pipeline</article-title>
 <surname>Krewinkel</surname>
 <given-names>Albert</given-names>
 </name>
+<role vocab="credit" degree-contribution="Equal"
+      vocab-identifier="https://credit.niso.org/"
+      vocab-term-identifier="https://credit.niso.org/contributor-roles/software/"
+      vocab-term="Software"
+>Software</role>
+<role vocab="credit
+      vocab-identifier="https://credit.niso.org/"
+      vocab-term-identifier="https://credit.niso.org/contributor-roles/methodology/"
+      vocab-term="Methodology"
+>Methodology</role>
 <email>albert@zeitkraut.de</email>
 <xref ref-type="aff" rid="aff-1"/>
 <xref ref-type="aff" rid="aff-2"/>
@@ -40,6 +50,11 @@ publishing pipeline</article-title>
 <surname>Bazán</surname>
 <given-names>Juanjo</given-names>
 </name>
+<role vocab="credit" degree-contribution="Equal"
+      vocab-identifier="https://credit.niso.org/"
+      vocab-term-identifier="https://credit.niso.org/contributor-roles/software/"
+      vocab-term="Software"
+>Software</role>
 <xref ref-type="aff" rid="aff-1"/>
 </contrib>
 <contrib contrib-type="author" equal-contrib="yes">
@@ -48,6 +63,16 @@ publishing pipeline</article-title>
 <surname>Smith</surname>
 <given-names>Arfon M.</given-names>
 </name>
+<role vocab="credit" degree-contribution="Equal"
+      vocab-identifier="https://credit.niso.org/"
+      vocab-term-identifier="https://credit.niso.org/contributor-roles/software/"
+      vocab-term="Software"
+>Software</role>
+<role vocab="credit" degree-contribution="Lead"
+      vocab-identifier="https://credit.niso.org/"
+      vocab-term-identifier="https://credit.niso.org/contributor-roles/supervision/"
+      vocab-term="Supervision"
+>Supervision</role>
 <xref ref-type="aff" rid="aff-1"/>
 <xref ref-type="aff" rid="aff-3"/>
 </contrib>
@@ -519,6 +544,106 @@ Software should use an OSI-approved license.
       surname: Nordmann</code>
       <p> </p>
     </sec>
+  </sec>
+  <sec id="contributor-roles">
+    <title>Contributor Roles</title>
+    <p>The
+    <ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles">Contribution
+    Role Taxonomy (CRediT)</ext-link> defines fourteen standard roles of
+    authors. Each author can be annotated with one or more contribution
+    roles.</p>
+    <list list-type="order">
+      <list-item>
+        <p><ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles/conceptualization">conceptualization</ext-link></p>
+      </list-item>
+      <list-item>
+        <p><ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles/data-curation">data-curation</ext-link></p>
+      </list-item>
+      <list-item>
+        <p><ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles/formal-analysis">formal-analysis</ext-link></p>
+      </list-item>
+      <list-item>
+        <p><ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles/funding-acquisition">funding-acquisition</ext-link></p>
+      </list-item>
+      <list-item>
+        <p><ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles/investigation">investigation</ext-link></p>
+      </list-item>
+      <list-item>
+        <p><ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles/methodology">methodology</ext-link></p>
+      </list-item>
+      <list-item>
+        <p><ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles/project-administration">project-administration</ext-link></p>
+      </list-item>
+      <list-item>
+        <p><ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles/resources">resources</ext-link></p>
+      </list-item>
+      <list-item>
+        <p><ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles/software">software</ext-link></p>
+      </list-item>
+      <list-item>
+        <p><ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles/supervision">supervision</ext-link></p>
+      </list-item>
+      <list-item>
+        <p><ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles/validation">validation</ext-link></p>
+      </list-item>
+      <list-item>
+        <p><ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles/visualization">visualization</ext-link></p>
+      </list-item>
+      <list-item>
+        <p><ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles/writing-original-draft">writing-original-draft</ext-link></p>
+      </list-item>
+      <list-item>
+        <p><ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles/writing-review-editing">writing-review-editing</ext-link></p>
+      </list-item>
+    </list>
+    <p>JATS also specifies three degrees which can be used to quantify
+    the impact of a contribution:</p>
+    <list list-type="order">
+      <list-item>
+        <p><monospace>Lead</monospace></p>
+      </list-item>
+      <list-item>
+        <p><monospace>Supporting</monospace></p>
+      </list-item>
+      <list-item>
+        <p><monospace>Equal</monospace> - for use if multiple equivalent
+        leads</p>
+      </list-item>
+    </list>
+    <p>Together, these can be used to identify which authors materially
+    contributed to the paper, such as through
+    <monospace>formal-analysis</monospace> or
+    <monospace>data-curation</monospace> and which authors contributed
+    immaterially, such as through <monospace>supervision</monospace>. It
+    also allows for saying if multiple people made the same kind of
+    contribution, who took the lead.</p>
+    <code language="yaml">authors:
+  - name: John Doe
+    affiliation: [ 1 ]
+    roles:
+      - credit: 'formal-analysis'
+        degree: 'lead'
+
+  - name: John Boss
+    affiliation: [ 1 ]
+    roles:
+      - credit: 'funding-acquisition'
+        degree: 'lead'
+      - credit: 'supervision'
+        degree: 'lead'</code>
+    <p>Roles are optional, and within roles, degrees are optional. It’s
+    possible to shorthand roles by using strings directly:</p>
+    <code language="yaml">authors:
+  - name: John Doe
+    affiliation: [ 1 ]
+    roles:
+      - 'formal-analysis'
+
+  - name: John Boss
+    affiliation: [ 1 ]
+    roles:
+      - 'funding-acquisition'
+      - 'supervision'</code>
   </sec>
   <sec id="affiliations">
     <title>Affiliations</title>

--- a/test/expected-draft/paper.preprint.tex
+++ b/test/expected-draft/paper.preprint.tex
@@ -786,4 +786,11 @@ block". \emph{Journal of Applied Behavior Analysis}, \emph{7}(3), 497.
 
 \end{CSLReferences}
 
+\section{Author Contributions}\label{author-contributions}
+\begin{enumerate}
+\item Albert Krewinkel - Software (Equal) & Methodology
+\item Juanjo Bazán - Software (Equal)
+\item Arfon M. Smith - Software (Equal) & Supervision (Lead)
+\end{enumerate}
+
 \end{document}

--- a/test/expected-draft/paper.tex
+++ b/test/expected-draft/paper.tex
@@ -848,6 +848,103 @@ The name parts can also be collected under the author's \texttt{name}:
 \end{Highlighting}
 \end{Shaded}
 
+\subsection{Contributor Roles}\label{contributor-roles}
+
+The \href{https://credit.niso.org/contributor-roles}{Contribution Role
+Taxonomy (CRediT)} defines fourteen standard roles of authors. Each
+author can be annotated with one or more contribution roles.
+
+\begin{enumerate}
+\def\labelenumi{\arabic{enumi}.}
+\tightlist
+\item
+  \href{https://credit.niso.org/contributor-roles/conceptualization}{conceptualization}
+\item
+  \href{https://credit.niso.org/contributor-roles/data-curation}{data-curation}
+\item
+  \href{https://credit.niso.org/contributor-roles/formal-analysis}{formal-analysis}
+\item
+  \href{https://credit.niso.org/contributor-roles/funding-acquisition}{funding-acquisition}
+\item
+  \href{https://credit.niso.org/contributor-roles/investigation}{investigation}
+\item
+  \href{https://credit.niso.org/contributor-roles/methodology}{methodology}
+\item
+  \href{https://credit.niso.org/contributor-roles/project-administration}{project-administration}
+\item
+  \href{https://credit.niso.org/contributor-roles/resources}{resources}
+\item
+  \href{https://credit.niso.org/contributor-roles/software}{software}
+\item
+  \href{https://credit.niso.org/contributor-roles/supervision}{supervision}
+\item
+  \href{https://credit.niso.org/contributor-roles/validation}{validation}
+\item
+  \href{https://credit.niso.org/contributor-roles/visualization}{visualization}
+\item
+  \href{https://credit.niso.org/contributor-roles/writing-original-draft}{writing-original-draft}
+\item
+  \href{https://credit.niso.org/contributor-roles/writing-review-editing}{writing-review-editing}
+\end{enumerate}
+
+JATS also specifies three degrees which can be used to quantify the
+impact of a contribution:
+
+\begin{enumerate}
+\def\labelenumi{\arabic{enumi}.}
+\tightlist
+\item
+  \texttt{Lead}
+\item
+  \texttt{Supporting}
+\item
+  \texttt{Equal} - for use if multiple equivalent leads
+\end{enumerate}
+
+Together, these can be used to identify which authors materially
+contributed to the paper, such as through \texttt{formal-analysis} or
+\texttt{data-curation} and which authors contributed immaterially, such
+as through \texttt{supervision}. It also allows for saying if multiple
+people made the same kind of contribution, who took the lead.
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\FunctionTok{authors}\KeywordTok{:}
+\AttributeTok{  }\KeywordTok{{-}}\AttributeTok{ }\FunctionTok{name}\KeywordTok{:}\AttributeTok{ John Doe}
+\AttributeTok{    }\FunctionTok{affiliation}\KeywordTok{:}\AttributeTok{ }\KeywordTok{[}\AttributeTok{ }\DecValTok{1}\AttributeTok{ }\KeywordTok{]}
+\AttributeTok{    }\FunctionTok{roles}\KeywordTok{:}
+\AttributeTok{      }\KeywordTok{{-}}\AttributeTok{ }\FunctionTok{credit}\KeywordTok{:}\AttributeTok{ }\StringTok{\textquotesingle{}formal{-}analysis\textquotesingle{}}
+\AttributeTok{        }\FunctionTok{degree}\KeywordTok{:}\AttributeTok{ }\StringTok{\textquotesingle{}lead\textquotesingle{}}
+
+\AttributeTok{  }\KeywordTok{{-}}\AttributeTok{ }\FunctionTok{name}\KeywordTok{:}\AttributeTok{ John Boss}
+\AttributeTok{    }\FunctionTok{affiliation}\KeywordTok{:}\AttributeTok{ }\KeywordTok{[}\AttributeTok{ }\DecValTok{1}\AttributeTok{ }\KeywordTok{]}
+\AttributeTok{    }\FunctionTok{roles}\KeywordTok{:}
+\AttributeTok{      }\KeywordTok{{-}}\AttributeTok{ }\FunctionTok{credit}\KeywordTok{:}\AttributeTok{ }\StringTok{\textquotesingle{}funding{-}acquisition\textquotesingle{}}
+\AttributeTok{        }\FunctionTok{degree}\KeywordTok{:}\AttributeTok{ }\StringTok{\textquotesingle{}lead\textquotesingle{}}
+\AttributeTok{      }\KeywordTok{{-}}\AttributeTok{ }\FunctionTok{credit}\KeywordTok{:}\AttributeTok{ }\StringTok{\textquotesingle{}supervision\textquotesingle{}}
+\AttributeTok{        }\FunctionTok{degree}\KeywordTok{:}\AttributeTok{ }\StringTok{\textquotesingle{}lead\textquotesingle{}}
+\end{Highlighting}
+\end{Shaded}
+
+Roles are optional, and within roles, degrees are optional. It's
+possible to shorthand roles by using strings directly:
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\FunctionTok{authors}\KeywordTok{:}
+\AttributeTok{  }\KeywordTok{{-}}\AttributeTok{ }\FunctionTok{name}\KeywordTok{:}\AttributeTok{ John Doe}
+\AttributeTok{    }\FunctionTok{affiliation}\KeywordTok{:}\AttributeTok{ }\KeywordTok{[}\AttributeTok{ }\DecValTok{1}\AttributeTok{ }\KeywordTok{]}
+\AttributeTok{    }\FunctionTok{roles}\KeywordTok{:}
+\AttributeTok{      }\KeywordTok{{-}}\AttributeTok{ }\StringTok{\textquotesingle{}formal{-}analysis\textquotesingle{}}
+
+\AttributeTok{  }\KeywordTok{{-}}\AttributeTok{ }\FunctionTok{name}\KeywordTok{:}\AttributeTok{ John Boss}
+\AttributeTok{    }\FunctionTok{affiliation}\KeywordTok{:}\AttributeTok{ }\KeywordTok{[}\AttributeTok{ }\DecValTok{1}\AttributeTok{ }\KeywordTok{]}
+\AttributeTok{    }\FunctionTok{roles}\KeywordTok{:}
+\AttributeTok{      }\KeywordTok{{-}}\AttributeTok{ }\StringTok{\textquotesingle{}funding{-}acquisition\textquotesingle{}}
+\AttributeTok{      }\KeywordTok{{-}}\AttributeTok{ }\StringTok{\textquotesingle{}supervision\textquotesingle{}}
+\end{Highlighting}
+\end{Shaded}
+
 \subsection{Affiliations}\label{affiliations}
 
 Each affiliation requires an \texttt{index} and \texttt{name}.
@@ -1028,5 +1125,12 @@ block". \emph{Journal of Applied Behavior Analysis}, \emph{7}(3), 497.
 \url{https://doi.org/10.1901/jaba.1974.7-497a}
 
 \end{CSLReferences}
+
+\section{Author Contributions}\label{author-contributions}
+\begin{enumerate}
+\item Albert Krewinkel - Software (Equal) & Methodology
+\item Juanjo Bazán - Software (Equal)
+\item Arfon M. Smith - Software (Equal) & Supervision (Lead)
+\end{enumerate}
 
 \end{document}

--- a/test/expected-pub/paper.jats/paper.jats
+++ b/test/expected-pub/paper.jats/paper.jats
@@ -28,6 +28,16 @@ publishing pipeline</article-title>
 <surname>Krewinkel</surname>
 <given-names>Albert</given-names>
 </name>
+<role vocab="credit" degree-contribution="Equal"
+      vocab-identifier="https://credit.niso.org/"
+      vocab-term-identifier="https://credit.niso.org/contributor-roles/software/"
+      vocab-term="Software"
+>Software</role>
+<role vocab="credit
+      vocab-identifier="https://credit.niso.org/"
+      vocab-term-identifier="https://credit.niso.org/contributor-roles/methodology/"
+      vocab-term="Methodology"
+>Methodology</role>
 <email>albert@zeitkraut.de</email>
 <xref ref-type="aff" rid="aff-1"/>
 <xref ref-type="aff" rid="aff-2"/>
@@ -40,6 +50,11 @@ publishing pipeline</article-title>
 <surname>Bazán</surname>
 <given-names>Juanjo</given-names>
 </name>
+<role vocab="credit" degree-contribution="Equal"
+      vocab-identifier="https://credit.niso.org/"
+      vocab-term-identifier="https://credit.niso.org/contributor-roles/software/"
+      vocab-term="Software"
+>Software</role>
 <xref ref-type="aff" rid="aff-1"/>
 </contrib>
 <contrib contrib-type="author" equal-contrib="yes">
@@ -48,6 +63,16 @@ publishing pipeline</article-title>
 <surname>Smith</surname>
 <given-names>Arfon M.</given-names>
 </name>
+<role vocab="credit" degree-contribution="Equal"
+      vocab-identifier="https://credit.niso.org/"
+      vocab-term-identifier="https://credit.niso.org/contributor-roles/software/"
+      vocab-term="Software"
+>Software</role>
+<role vocab="credit" degree-contribution="Lead"
+      vocab-identifier="https://credit.niso.org/"
+      vocab-term-identifier="https://credit.niso.org/contributor-roles/supervision/"
+      vocab-term="Supervision"
+>Supervision</role>
 <xref ref-type="aff" rid="aff-1"/>
 <xref ref-type="aff" rid="aff-3"/>
 </contrib>
@@ -519,6 +544,106 @@ Software should use an OSI-approved license.
       surname: Nordmann</code>
       <p> </p>
     </sec>
+  </sec>
+  <sec id="contributor-roles">
+    <title>Contributor Roles</title>
+    <p>The
+    <ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles">Contribution
+    Role Taxonomy (CRediT)</ext-link> defines fourteen standard roles of
+    authors. Each author can be annotated with one or more contribution
+    roles.</p>
+    <list list-type="order">
+      <list-item>
+        <p><ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles/conceptualization">conceptualization</ext-link></p>
+      </list-item>
+      <list-item>
+        <p><ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles/data-curation">data-curation</ext-link></p>
+      </list-item>
+      <list-item>
+        <p><ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles/formal-analysis">formal-analysis</ext-link></p>
+      </list-item>
+      <list-item>
+        <p><ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles/funding-acquisition">funding-acquisition</ext-link></p>
+      </list-item>
+      <list-item>
+        <p><ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles/investigation">investigation</ext-link></p>
+      </list-item>
+      <list-item>
+        <p><ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles/methodology">methodology</ext-link></p>
+      </list-item>
+      <list-item>
+        <p><ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles/project-administration">project-administration</ext-link></p>
+      </list-item>
+      <list-item>
+        <p><ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles/resources">resources</ext-link></p>
+      </list-item>
+      <list-item>
+        <p><ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles/software">software</ext-link></p>
+      </list-item>
+      <list-item>
+        <p><ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles/supervision">supervision</ext-link></p>
+      </list-item>
+      <list-item>
+        <p><ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles/validation">validation</ext-link></p>
+      </list-item>
+      <list-item>
+        <p><ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles/visualization">visualization</ext-link></p>
+      </list-item>
+      <list-item>
+        <p><ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles/writing-original-draft">writing-original-draft</ext-link></p>
+      </list-item>
+      <list-item>
+        <p><ext-link ext-link-type="uri" xlink:href="https://credit.niso.org/contributor-roles/writing-review-editing">writing-review-editing</ext-link></p>
+      </list-item>
+    </list>
+    <p>JATS also specifies three degrees which can be used to quantify
+    the impact of a contribution:</p>
+    <list list-type="order">
+      <list-item>
+        <p><monospace>Lead</monospace></p>
+      </list-item>
+      <list-item>
+        <p><monospace>Supporting</monospace></p>
+      </list-item>
+      <list-item>
+        <p><monospace>Equal</monospace> - for use if multiple equivalent
+        leads</p>
+      </list-item>
+    </list>
+    <p>Together, these can be used to identify which authors materially
+    contributed to the paper, such as through
+    <monospace>formal-analysis</monospace> or
+    <monospace>data-curation</monospace> and which authors contributed
+    immaterially, such as through <monospace>supervision</monospace>. It
+    also allows for saying if multiple people made the same kind of
+    contribution, who took the lead.</p>
+    <code language="yaml">authors:
+  - name: John Doe
+    affiliation: [ 1 ]
+    roles:
+      - credit: 'formal-analysis'
+        degree: 'lead'
+
+  - name: John Boss
+    affiliation: [ 1 ]
+    roles:
+      - credit: 'funding-acquisition'
+        degree: 'lead'
+      - credit: 'supervision'
+        degree: 'lead'</code>
+    <p>Roles are optional, and within roles, degrees are optional. It’s
+    possible to shorthand roles by using strings directly:</p>
+    <code language="yaml">authors:
+  - name: John Doe
+    affiliation: [ 1 ]
+    roles:
+      - 'formal-analysis'
+
+  - name: John Boss
+    affiliation: [ 1 ]
+    roles:
+      - 'funding-acquisition'
+      - 'supervision'</code>
   </sec>
   <sec id="affiliations">
     <title>Affiliations</title>

--- a/test/expected-pub/paper.preprint.tex
+++ b/test/expected-pub/paper.preprint.tex
@@ -786,4 +786,11 @@ block". \emph{Journal of Applied Behavior Analysis}, \emph{7}(3), 497.
 
 \end{CSLReferences}
 
+\section{Author Contributions}\label{author-contributions}
+\begin{enumerate}
+\item Albert Krewinkel - Software (Equal) & Methodology
+\item Juanjo Bazán - Software (Equal)
+\item Arfon M. Smith - Software (Equal) & Supervision (Lead)
+\end{enumerate}
+
 \end{document}

--- a/test/expected-pub/paper.tex
+++ b/test/expected-pub/paper.tex
@@ -846,6 +846,103 @@ The name parts can also be collected under the author's \texttt{name}:
 \end{Highlighting}
 \end{Shaded}
 
+\subsection{Contributor Roles}\label{contributor-roles}
+
+The \href{https://credit.niso.org/contributor-roles}{Contribution Role
+Taxonomy (CRediT)} defines fourteen standard roles of authors. Each
+author can be annotated with one or more contribution roles.
+
+\begin{enumerate}
+\def\labelenumi{\arabic{enumi}.}
+\tightlist
+\item
+  \href{https://credit.niso.org/contributor-roles/conceptualization}{conceptualization}
+\item
+  \href{https://credit.niso.org/contributor-roles/data-curation}{data-curation}
+\item
+  \href{https://credit.niso.org/contributor-roles/formal-analysis}{formal-analysis}
+\item
+  \href{https://credit.niso.org/contributor-roles/funding-acquisition}{funding-acquisition}
+\item
+  \href{https://credit.niso.org/contributor-roles/investigation}{investigation}
+\item
+  \href{https://credit.niso.org/contributor-roles/methodology}{methodology}
+\item
+  \href{https://credit.niso.org/contributor-roles/project-administration}{project-administration}
+\item
+  \href{https://credit.niso.org/contributor-roles/resources}{resources}
+\item
+  \href{https://credit.niso.org/contributor-roles/software}{software}
+\item
+  \href{https://credit.niso.org/contributor-roles/supervision}{supervision}
+\item
+  \href{https://credit.niso.org/contributor-roles/validation}{validation}
+\item
+  \href{https://credit.niso.org/contributor-roles/visualization}{visualization}
+\item
+  \href{https://credit.niso.org/contributor-roles/writing-original-draft}{writing-original-draft}
+\item
+  \href{https://credit.niso.org/contributor-roles/writing-review-editing}{writing-review-editing}
+\end{enumerate}
+
+JATS also specifies three degrees which can be used to quantify the
+impact of a contribution:
+
+\begin{enumerate}
+\def\labelenumi{\arabic{enumi}.}
+\tightlist
+\item
+  \texttt{Lead}
+\item
+  \texttt{Supporting}
+\item
+  \texttt{Equal} - for use if multiple equivalent leads
+\end{enumerate}
+
+Together, these can be used to identify which authors materially
+contributed to the paper, such as through \texttt{formal-analysis} or
+\texttt{data-curation} and which authors contributed immaterially, such
+as through \texttt{supervision}. It also allows for saying if multiple
+people made the same kind of contribution, who took the lead.
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\FunctionTok{authors}\KeywordTok{:}
+\AttributeTok{  }\KeywordTok{{-}}\AttributeTok{ }\FunctionTok{name}\KeywordTok{:}\AttributeTok{ John Doe}
+\AttributeTok{    }\FunctionTok{affiliation}\KeywordTok{:}\AttributeTok{ }\KeywordTok{[}\AttributeTok{ }\DecValTok{1}\AttributeTok{ }\KeywordTok{]}
+\AttributeTok{    }\FunctionTok{roles}\KeywordTok{:}
+\AttributeTok{      }\KeywordTok{{-}}\AttributeTok{ }\FunctionTok{credit}\KeywordTok{:}\AttributeTok{ }\StringTok{\textquotesingle{}formal{-}analysis\textquotesingle{}}
+\AttributeTok{        }\FunctionTok{degree}\KeywordTok{:}\AttributeTok{ }\StringTok{\textquotesingle{}lead\textquotesingle{}}
+
+\AttributeTok{  }\KeywordTok{{-}}\AttributeTok{ }\FunctionTok{name}\KeywordTok{:}\AttributeTok{ John Boss}
+\AttributeTok{    }\FunctionTok{affiliation}\KeywordTok{:}\AttributeTok{ }\KeywordTok{[}\AttributeTok{ }\DecValTok{1}\AttributeTok{ }\KeywordTok{]}
+\AttributeTok{    }\FunctionTok{roles}\KeywordTok{:}
+\AttributeTok{      }\KeywordTok{{-}}\AttributeTok{ }\FunctionTok{credit}\KeywordTok{:}\AttributeTok{ }\StringTok{\textquotesingle{}funding{-}acquisition\textquotesingle{}}
+\AttributeTok{        }\FunctionTok{degree}\KeywordTok{:}\AttributeTok{ }\StringTok{\textquotesingle{}lead\textquotesingle{}}
+\AttributeTok{      }\KeywordTok{{-}}\AttributeTok{ }\FunctionTok{credit}\KeywordTok{:}\AttributeTok{ }\StringTok{\textquotesingle{}supervision\textquotesingle{}}
+\AttributeTok{        }\FunctionTok{degree}\KeywordTok{:}\AttributeTok{ }\StringTok{\textquotesingle{}lead\textquotesingle{}}
+\end{Highlighting}
+\end{Shaded}
+
+Roles are optional, and within roles, degrees are optional. It's
+possible to shorthand roles by using strings directly:
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\FunctionTok{authors}\KeywordTok{:}
+\AttributeTok{  }\KeywordTok{{-}}\AttributeTok{ }\FunctionTok{name}\KeywordTok{:}\AttributeTok{ John Doe}
+\AttributeTok{    }\FunctionTok{affiliation}\KeywordTok{:}\AttributeTok{ }\KeywordTok{[}\AttributeTok{ }\DecValTok{1}\AttributeTok{ }\KeywordTok{]}
+\AttributeTok{    }\FunctionTok{roles}\KeywordTok{:}
+\AttributeTok{      }\KeywordTok{{-}}\AttributeTok{ }\StringTok{\textquotesingle{}formal{-}analysis\textquotesingle{}}
+
+\AttributeTok{  }\KeywordTok{{-}}\AttributeTok{ }\FunctionTok{name}\KeywordTok{:}\AttributeTok{ John Boss}
+\AttributeTok{    }\FunctionTok{affiliation}\KeywordTok{:}\AttributeTok{ }\KeywordTok{[}\AttributeTok{ }\DecValTok{1}\AttributeTok{ }\KeywordTok{]}
+\AttributeTok{    }\FunctionTok{roles}\KeywordTok{:}
+\AttributeTok{      }\KeywordTok{{-}}\AttributeTok{ }\StringTok{\textquotesingle{}funding{-}acquisition\textquotesingle{}}
+\AttributeTok{      }\KeywordTok{{-}}\AttributeTok{ }\StringTok{\textquotesingle{}supervision\textquotesingle{}}
+\end{Highlighting}
+\end{Shaded}
+
 \subsection{Affiliations}\label{affiliations}
 
 Each affiliation requires an \texttt{index} and \texttt{name}.
@@ -1026,5 +1123,12 @@ block". \emph{Journal of Applied Behavior Analysis}, \emph{7}(3), 497.
 \url{https://doi.org/10.1901/jaba.1974.7-497a}
 
 \end{CSLReferences}
+
+\section{Author Contributions}\label{author-contributions}
+\begin{enumerate}
+\item Albert Krewinkel - Software (Equal) & Methodology
+\item Juanjo Bazán - Software (Equal)
+\item Arfon M. Smith - Software (Equal) & Supervision (Lead)
+\end{enumerate}
 
 \end{document}


### PR DESCRIPTION
Closes #73. Supersedes #75


This PR enables annotating author roles using the [Contribution Role Taxonomy (CRediT)](https://credit.niso.org/contributor-roles). It also enables (optionally) annotating the contribution degree, as [suggested by JATS](https://jats.nlm.nih.gov/archiving/tag-library/1.3/attribute/degree-contribution.html).

It does the following:

- [x] Add contribution list to end of `default.latex` (after reference list)
- [x] Add contribution list to end of `preprint.latex` (after reference list)
- [x] JATS support
   - [x] Implementation and testing 
   - [x] Wait for a 3.6.3 release of Pandoc containing https://github.com/jgm/pandoc/pull/10153, which does the heavy lifting

## Blockers

- [x] #100, superseded by https://github.com/openjournals/inara/pull/115

## Demo

Here's what this looks like at the end of the main PDF build:

<img width="874" alt="Screenshot 2024-09-02 at 13 19 52" src="https://github.com/user-attachments/assets/71981141-d135-47e6-9a5e-0acc172f8944">

## Future Work

Future work for future PRs:

1. Work with Crossref to get a reasonable model for capturing this. Crossref is currently [discussing](https://docs.google.com/document/d/1BwCHs9mEj0_t2AuIVzchv4b-yOLlbWbCr0JjJLSsm3c/edit#heading=h.hget944rrkj6) supporting this.

4. See how this fits in the ConTeXt template, if this gets picked up by Open Journals
