### PR TITLE
Fix Crossref XML: Affiliations

### DIFF
--- a/data/filters/prepare-affiliations.lua
+++ b/data/filters/prepare-affiliations.lua
@@ -2,7 +2,7 @@
 -- author dictionary to contain all the information, not
 -- just the index in the global affiliation list
 
-local function perepare_affiliations (meta)
+local function prepare_affiliations (meta)
   -- note that there's a difference between meta.authors (the original)
   -- and meta.author (the processed one)
   for _, author in ipairs(meta.authors or {}) do
@@ -32,7 +32,7 @@ local function perepare_affiliations (meta)
 end
 
 function Meta (meta)
-  local ok, result = pcall(perepare_affiliations, meta)
+  local ok, result = pcall(prepare_affiliations, meta)
   if ok then
     return result
   end

--- a/data/templates/default.crossref
+++ b/data/templates/default.crossref
@@ -67,11 +67,11 @@ $endif$
 $if(it.suffix)$
             <suffix>${it.suffix}</suffix>
 $endif$
-$if(it.orcid)$
-            <ORCID>https://orcid.org/${it.orcid}</ORCID>
-$endif$
 $if(it.afxml)$
             $it.afxml$
+$endif$
+$if(it.orcid)$
+            <ORCID>https://orcid.org/${it.orcid}</ORCID>
 $endif$
           </person_name>
 $endfor$

--- a/data/templates/default.crossref
+++ b/data/templates/default.crossref
@@ -49,11 +49,11 @@ $endif$
 $if(it.suffix)$
             <suffix>${it.suffix}</suffix>
 $endif$
-$if(it.orcid)$
-            <ORCID>https://orcid.org/${it.orcid}</ORCID>
-$endif$
 $if(it.afxml)$
             $it.afxml$
+$endif$
+$if(it.orcid)$
+            <ORCID>https://orcid.org/${it.orcid}</ORCID>
 $endif$
           </person_name>
 $endfor$

--- a/test/expected-draft/paper.crossref
+++ b/test/expected-draft/paper.crossref
@@ -44,31 +44,31 @@ publishing pipeline</title>
           <person_name sequence="first" contributor_role="author">
             <given_name>Albert</given_name>
             <surname>Krewinkel</surname>
-            <ORCID>https://orcid.org/0000-0002-9455-0796</ORCID>
             <affiliations>
               <institution><institution_name>Open Journals</institution_name></institution>
               <institution><institution_name>Pandoc Development Team</institution_name></institution>
               <institution><institution_name>Technische Universitaet Hamburg</institution_name><institution_id type="ror">https://ror.org/04bs1pb34</institution_id></institution>
             </affiliations>
+            <ORCID>https://orcid.org/0000-0002-9455-0796</ORCID>
           </person_name>
           <person_name sequence="additional"
                        contributor_role="author">
             <given_name>Juanjo</given_name>
             <surname>Bazán</surname>
-            <ORCID>https://orcid.org/0000-0001-7699-3983</ORCID>
             <affiliations>
               <institution><institution_name>Open Journals</institution_name></institution>
             </affiliations>
+            <ORCID>https://orcid.org/0000-0001-7699-3983</ORCID>
           </person_name>
           <person_name sequence="additional"
                        contributor_role="author">
             <given_name>Arfon M.</given_name>
             <surname>Smith</surname>
-            <ORCID>https://orcid.org/0000-0002-3957-2474</ORCID>
             <affiliations>
               <institution><institution_name>Open Journals</institution_name></institution>
               <institution><institution_name>GitHub</institution_name></institution>
             </affiliations>
+            <ORCID>https://orcid.org/0000-0002-3957-2474</ORCID>
           </person_name>
         </contributors>
         <publication_date>

--- a/test/expected-pub/paper.crossref
+++ b/test/expected-pub/paper.crossref
@@ -44,31 +44,31 @@ publishing pipeline</title>
           <person_name sequence="first" contributor_role="author">
             <given_name>Albert</given_name>
             <surname>Krewinkel</surname>
-            <ORCID>https://orcid.org/0000-0002-9455-0796</ORCID>
             <affiliations>
               <institution><institution_name>Open Journals</institution_name></institution>
               <institution><institution_name>Pandoc Development Team</institution_name></institution>
               <institution><institution_name>Technische Universitaet Hamburg</institution_name><institution_id type="ror">https://ror.org/04bs1pb34</institution_id></institution>
             </affiliations>
+            <ORCID>https://orcid.org/0000-0002-9455-0796</ORCID>
           </person_name>
           <person_name sequence="additional"
                        contributor_role="author">
             <given_name>Juanjo</given_name>
             <surname>Bazán</surname>
-            <ORCID>https://orcid.org/0000-0001-7699-3983</ORCID>
             <affiliations>
               <institution><institution_name>Open Journals</institution_name></institution>
             </affiliations>
+            <ORCID>https://orcid.org/0000-0001-7699-3983</ORCID>
           </person_name>
           <person_name sequence="additional"
                        contributor_role="author">
             <given_name>Arfon M.</given_name>
             <surname>Smith</surname>
-            <ORCID>https://orcid.org/0000-0002-3957-2474</ORCID>
             <affiliations>
               <institution><institution_name>Open Journals</institution_name></institution>
               <institution><institution_name>GitHub</institution_name></institution>
             </affiliations>
+            <ORCID>https://orcid.org/0000-0002-3957-2474</ORCID>
           </person_name>
         </contributors>
         <publication_date>


### PR DESCRIPTION
The validation of the generated Crossref XML file against the schema (version 5.3.1) failed when ORCID and affiliations are not in the [expected order](https://data.crossref.org/reports/help/schema_doc/5.3.1/crossref5_3_1_xsd.html#person_name). This PR moves `<affiliations>` right before `<ORCID>`.

Closes #92