### PR TITLE
Fix problem in high-verbosity mode

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -82,8 +82,12 @@ if [ "$verbosity" -ge 1 ]; then
     printf 'article_info_option  : %s\n' "${article_info_option}"
 fi
 if [ "$verbosity" -ge 2 ]; then
-    printf "\nContent of metadata defaults file:\n"
-    cat "${article_info_file}"
+    if [ -n "${article_info_file}" ] && [ -f "${article_info_file}" ]; then
+        printf "\nContent of metadata defaults file:\n"
+        cat "${article_info_file}"
+    else
+        printf "No valid metadata defaults file specified.\n"
+    fi
 fi
 
 # All paths in the document are expected to be relative to the paper


### PR DESCRIPTION
Currently, when verbosity is greater/equal 2 and no `article_info_file` is specified via the `-m` option, the script fails as it tries to `cat` the file without checking whether `article_info_file` is specified.

This PR adds an if-clause to perform this check beforehand and prevent errors in high-verbosity mode.