### PR TITLE
Update pandoc docker image from 3.2 to 3.6.3

### DIFF
--- a/.github/workflows/example-doc.yml
+++ b/.github/workflows/example-doc.yml
@@ -33,8 +33,7 @@ jobs:
 
       - name: Build draft PDF
         run: >-
-          cd example && \
-          docker run \
+          cd example && docker run \
               --volume "$(pwd):/data" \
               --user "$(id -u):$(id -g)" \
               inara:edgiest \

--- a/.github/workflows/example-doc.yml
+++ b/.github/workflows/example-doc.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Build draft PDF
         run: >-
-          cd example
+          cd example && \
           docker run \
               --volume "$(pwd):/data" \
               --user "$(id -u):$(id -g)" \

--- a/.github/workflows/example-doc.yml
+++ b/.github/workflows/example-doc.yml
@@ -33,11 +33,12 @@ jobs:
 
       - name: Build draft PDF
         run: >-
+          cd example
           docker run \
               --volume "$(pwd):/data" \
               --user "$(id -u):$(id -g)" \
               inara:edgiest \
-              -o "jats,contextpdf,crossref,preprint,tex,pdf" example/paper.md
+              -o "jats,contextpdf,crossref,preprint,tex,pdf" paper.md
 
       - name: Upload draft PDF
         uses: actions/upload-artifact@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Released 2024-05-11
-FROM pandoc/latex:3.2.0-alpine
+# Released 2025-02-10
+FROM pandoc/latex:3.6.3-alpine
 
 RUN apk add --no-cache ttf-hack
 

--- a/test/expected-draft/paper.tex
+++ b/test/expected-draft/paper.tex
@@ -484,9 +484,9 @@ The markup in Markdown should be semantic, not presentations. The table
 below gives a small example.
 
 \begin{longtable}[]{@{}
-  >{\raggedright\arraybackslash}p{(\columnwidth - 4\tabcolsep) * \real{0.3014}}
-  >{\centering\arraybackslash}p{(\columnwidth - 4\tabcolsep) * \real{0.3562}}
-  >{\centering\arraybackslash}p{(\columnwidth - 4\tabcolsep) * \real{0.3288}}@{}}
+  >{\raggedright\arraybackslash}p{(\linewidth - 4\tabcolsep) * \real{0.3014}}
+  >{\centering\arraybackslash}p{(\linewidth - 4\tabcolsep) * \real{0.3562}}
+  >{\centering\arraybackslash}p{(\linewidth - 4\tabcolsep) * \real{0.3288}}@{}}
 \caption{Basic inline markup and examples.}\tabularnewline
 \toprule\noalign{}
 \begin{minipage}[b]{\linewidth}\raggedright
@@ -567,12 +567,12 @@ can sometimes be useful to give images an explicit height and/or width,
 e.g.~when adding an image as part of a paragraph. The Markdown
 \texttt{!{[}Nyan\ cat{]}(nyan-cat.png)\{height="9pt"\}} includes the
 image ``nyan-cat.png''
-\includegraphics[width=\textwidth,height=0.125in]{images/nyan-cat.png}
+\includegraphics[width=\linewidth,height=0.125in,keepaspectratio]{images/nyan-cat.png}
 while scaling it to a height of 9\,pt.
 
 \begin{figure}
 \centering
-\includegraphics{images/mandrill.jpg}
+\pandocbounded{\includegraphics[keepaspectratio]{images/mandrill.jpg}}
 \caption{The ``Mandrill'' standard test image, sometimes erroneously
 called ``Baboon'', is a popular sample photo and used in image
 processing research.}\label{fig:mandrill}
@@ -885,7 +885,7 @@ are supported. In a nutshell, elements that were marked with
 
 \begin{figure}
 \centering
-\includegraphics[width=1\textwidth,height=\textheight]{images/sylt.jpg}
+\includegraphics[width=1\linewidth,height=\textheight,keepaspectratio]{images/sylt.jpg}
 \caption{View of coastal dunes in a nature reserve on Sylt, an island in
 the North Sea. Sylt (Danish: \emph{Slid}) is Germany's northernmost
 island.}\label{sylt}
@@ -909,11 +909,11 @@ type and number of the referenced float. E.g., in this document
 gives ``\ref{proglangs}''.
 
 \begin{longtable}[]{@{}
-  >{\raggedright\arraybackslash}p{(\columnwidth - 8\tabcolsep) * \real{0.1493}}
-  >{\centering\arraybackslash}p{(\columnwidth - 8\tabcolsep) * \real{0.2537}}
-  >{\centering\arraybackslash}p{(\columnwidth - 8\tabcolsep) * \real{0.2836}}
-  >{\raggedright\arraybackslash}p{(\columnwidth - 8\tabcolsep) * \real{0.1791}}
-  >{\raggedright\arraybackslash}p{(\columnwidth - 8\tabcolsep) * \real{0.1343}}@{}}
+  >{\raggedright\arraybackslash}p{(\linewidth - 8\tabcolsep) * \real{0.1493}}
+  >{\centering\arraybackslash}p{(\linewidth - 8\tabcolsep) * \real{0.2537}}
+  >{\centering\arraybackslash}p{(\linewidth - 8\tabcolsep) * \real{0.2836}}
+  >{\raggedright\arraybackslash}p{(\linewidth - 8\tabcolsep) * \real{0.1791}}
+  >{\raggedright\arraybackslash}p{(\linewidth - 8\tabcolsep) * \real{0.1343}}@{}}
 \caption{Comparison of programming languages used in the publishing
 tool. {}}\tabularnewline
 \toprule\noalign{}

--- a/test/expected-pub/paper.tex
+++ b/test/expected-pub/paper.tex
@@ -482,9 +482,9 @@ The markup in Markdown should be semantic, not presentations. The table
 below gives a small example.
 
 \begin{longtable}[]{@{}
-  >{\raggedright\arraybackslash}p{(\columnwidth - 4\tabcolsep) * \real{0.3014}}
-  >{\centering\arraybackslash}p{(\columnwidth - 4\tabcolsep) * \real{0.3562}}
-  >{\centering\arraybackslash}p{(\columnwidth - 4\tabcolsep) * \real{0.3288}}@{}}
+  >{\raggedright\arraybackslash}p{(\linewidth - 4\tabcolsep) * \real{0.3014}}
+  >{\centering\arraybackslash}p{(\linewidth - 4\tabcolsep) * \real{0.3562}}
+  >{\centering\arraybackslash}p{(\linewidth - 4\tabcolsep) * \real{0.3288}}@{}}
 \caption{Basic inline markup and examples.}\tabularnewline
 \toprule\noalign{}
 \begin{minipage}[b]{\linewidth}\raggedright
@@ -565,12 +565,12 @@ can sometimes be useful to give images an explicit height and/or width,
 e.g.~when adding an image as part of a paragraph. The Markdown
 \texttt{!{[}Nyan\ cat{]}(nyan-cat.png)\{height="9pt"\}} includes the
 image ``nyan-cat.png''
-\includegraphics[width=\textwidth,height=0.125in]{images/nyan-cat.png}
+\includegraphics[width=\linewidth,height=0.125in,keepaspectratio]{images/nyan-cat.png}
 while scaling it to a height of 9\,pt.
 
 \begin{figure}
 \centering
-\includegraphics{images/mandrill.jpg}
+\pandocbounded{\includegraphics[keepaspectratio]{images/mandrill.jpg}}
 \caption{The ``Mandrill'' standard test image, sometimes erroneously
 called ``Baboon'', is a popular sample photo and used in image
 processing research.}\label{fig:mandrill}
@@ -883,7 +883,7 @@ are supported. In a nutshell, elements that were marked with
 
 \begin{figure}
 \centering
-\includegraphics[width=1\textwidth,height=\textheight]{images/sylt.jpg}
+\includegraphics[width=1\linewidth,height=\textheight,keepaspectratio]{images/sylt.jpg}
 \caption{View of coastal dunes in a nature reserve on Sylt, an island in
 the North Sea. Sylt (Danish: \emph{Slid}) is Germany's northernmost
 island.}\label{sylt}
@@ -907,11 +907,11 @@ type and number of the referenced float. E.g., in this document
 gives ``\ref{proglangs}''.
 
 \begin{longtable}[]{@{}
-  >{\raggedright\arraybackslash}p{(\columnwidth - 8\tabcolsep) * \real{0.1493}}
-  >{\centering\arraybackslash}p{(\columnwidth - 8\tabcolsep) * \real{0.2537}}
-  >{\centering\arraybackslash}p{(\columnwidth - 8\tabcolsep) * \real{0.2836}}
-  >{\raggedright\arraybackslash}p{(\columnwidth - 8\tabcolsep) * \real{0.1791}}
-  >{\raggedright\arraybackslash}p{(\columnwidth - 8\tabcolsep) * \real{0.1343}}@{}}
+  >{\raggedright\arraybackslash}p{(\linewidth - 8\tabcolsep) * \real{0.1493}}
+  >{\centering\arraybackslash}p{(\linewidth - 8\tabcolsep) * \real{0.2537}}
+  >{\centering\arraybackslash}p{(\linewidth - 8\tabcolsep) * \real{0.2836}}
+  >{\raggedright\arraybackslash}p{(\linewidth - 8\tabcolsep) * \real{0.1791}}
+  >{\raggedright\arraybackslash}p{(\linewidth - 8\tabcolsep) * \real{0.1343}}@{}}
 \caption{Comparison of programming languages used in the publishing
 tool. {}}\tabularnewline
 \toprule\noalign{}


### PR DESCRIPTION
This PR does the following:

- [x] Updates the dockerfile from 3.2 (2024-05-11) to 3.6.3 (2025-02-10)
- [x] Updates the LaTeX outputs with minor changes due to pandoc version bump, see explanation below
- [ ] Debug issues in the example paper build workflow

The new version of pandoc causes the following minor changes in latex output:

1. **Tables** - tables are now sized with `\linewidth` instead of `\columnwidth`. This affects the tables captioned `Basic inline markup and examples` and `Comparison of programming languages used in the publishing
tool`
3. **Inline Images** - the width of the nyan-cat image and sylt images are now determined by the `\linewidth` instead of `\textwidth`. Inline images now get the `keepaspectratio` flag
4. **Free-standing Images** - the mandrill image is now wrapped with`\pandocbounded{}`. Free-standing images now get the `keepaspectratio` flag.

   This command was introduced in Pandoc in https://github.com/jgm/pandoc/commit/26b25a4428815b04c255e33e95ee86ca7b6ee30e and lives in https://github.com/jgm/pandoc/blob/786356ace43d622866041f021b09452441ced009/data/templates/common.latex#L99-L108 in Pandoc 3.6.3. This requires adding the corresponding command to Inara's latex template

## Blockers

It appears that two pre-existing issues that were suppressed by pandoc 3.2 are now causing failures for pandoc 3.6 (or at least, obscuring other errors that are happening with 3.6), so it would be nice to address these first in isolation:

- #104
- #102 / #103
