### PR TITLE
Update example paper build workflow

### DIFF
--- a/.github/workflows/example-doc.yml
+++ b/.github/workflows/example-doc.yml
@@ -6,10 +6,12 @@ on:
     paths:
       - 'example/*'
       - 'data/templates/*'
+      - "Dockerfile"
   pull_request:
     paths:
       - 'example/*'
       - 'data/templates/*'
+      - "Dockerfile"
     # Build, but don't push on pull requests
 
 jobs:
@@ -38,7 +40,7 @@ jobs:
               -o "jats,contextpdf,crossref,preprint,tex,pdf" example/paper.md
 
       - name: Upload draft PDF
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: draft
           path: |
@@ -58,7 +60,7 @@ jobs:
               -o "jats,contextpdf,crossref,preprint,tex,pdf" -p example/paper.md
 
       - name: Upload production PDF
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: production
           path: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# Released 2024-05-11
 FROM pandoc/latex:3.2.0-alpine
 
 RUN apk add --no-cache ttf-hack


### PR DESCRIPTION
This PR was spun out from #100. It makes two improvements:

- [x] Updates the example paper build workflow to get triggered on changes to the Dockerfile, useful for testing.
- [x] Updates from `actions/upload-artifact@v3` to `actions/upload-artifact@v4` since v3 is deprecated, and GitHub Actions is aggressively rejecting jobs using it. 

The `draft` and `production` zips generated by this updated workflow triggered on the commit in this PR can be found at https://github.com/openjournals/inara/actions/runs/13239708953