### PR TITLE
Fix table reference in `example.md`

### DIFF
--- a/example/paper.md
+++ b/example/paper.md
@@ -421,7 +421,7 @@ number of the referenced float. E.g., in this document
 `\ref{proglangs}` gives "\ref{proglangs}".
 
 : Comparison of programming languages used in the publishing tool.
-  []{label="proglangs"}
+  []{#proglangs}
 
 | Language | Typing          | Garbage Collected | Evaluation | Created |
 |----------|:---------------:|:-----------------:|------------|---------|


### PR DESCRIPTION
Closes #102

However, this change surfaced some unrelated issues for bibliographic citations