### PR TITLE
Force tlmgr to use 2024 packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM pandoc/latex:3.2.0-alpine
 RUN apk add --no-cache ttf-hack
 
 # Install additional LaTeX packages
-RUN tlmgr update --self && tlmgr install \
+RUN tlmgr option repository http://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2024/tlnet-final && \ 
+  tlmgr update --self && tlmgr install \
   algorithmicx \
   algorithms \
   collection-context \


### PR DESCRIPTION
I triggered a build recently with base image `3.2.0`, and ran into the following error:

```
2.301 tlmgr: Local TeX Live (2024) is older than remote repository (2025).
2.301 Cross release updates are only supported with
2.301   update-tlmgr-latest(.sh/.exe) --update
2.301 See https://tug.org/texlive/upgrade.html for details.
```

For some reason the CTAN mirror throws 404, so I added a repository from Utah edu, resolves the issue. 



