### PR TITLE
pandoc: turn warnings into errors

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -127,6 +127,7 @@ for format in $(printf "%s" "$outformats" | sed -e 's/,/ /g'); do
 	      --variable="${JOURNAL}" \
         --variable=retraction:"$retraction" \
         --variable=draft:"$draft" \
+		--fail-if-warnings=true \
         --metadata=draft:"$draft" \
         --log="$logfile" \
         "$input_file" \


### PR DESCRIPTION
For instance, it will fail if a reference is incorrect:
```bash
[WARNING] [makePDF] LaTeX Warning: Citation `ref-zhang-2021' on page 5 undefined
  on input line 722.
[WARNING] [makePDF] LaTeX Warning: There were undefined references.
Failing because there were warnings.
```

Fixes https://github.com/openjournals/inara/issues/114.