### PR TITLE
Fix CJK characters silently dropped in author names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,9 @@ COPY ./fonts/libre-franklin $OSFONTDIR/libre-franklin
 
 RUN TERM=dumb luaotfload-tool --update \
   && chmod -R o+w /opt/texlive/texdir/texmf-var \
-  && apk add --no-cache ttf-opensans \
+  && apk add --no-cache ttf-opensans font-noto-cjk \
   && fc-cache -sfv $OSFONTDIR/libre-franklin \
+  && luaotfload-tool --update \
   && mtxrun --generate \
   && mtxrun --script font --reload
 

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -221,6 +221,18 @@ $-- Taken from fonts.latex and specialized for LuaLaTeX --$
 $font-settings.latex()$
 
 %% Font settings
+% Register a CJK fallback font for LuaLaTeX so that CJK characters in author
+% names (and other text) render instead of being silently dropped. The fallback
+% must be declared before fontsetup loads the New CM fonts so that every font
+% defined by fontsetup inherits it via \defaultfontfeatures+.
+\ifLuaTeX
+  \directlua{
+    luaotfload.add_fallback("cjk_fallback", {
+      "Noto Sans CJK SC:mode=harf;",
+    })
+  }
+  \defaultfontfeatures+{RawFeature={fallback=cjk_fallback}}
+\fi
 \usepackage{fontsetup} % Lazy way to get proper Greek lowercase glyphs
 
 % Use Hack https://sourcefoundry.org/hack/

--- a/test/expected-draft/paper.tex
+++ b/test/expected-draft/paper.tex
@@ -339,6 +339,18 @@ publishing pipeline. \emph{Journal of Open Source Software},
 }{}
 
 %% Font settings
+% Register a CJK fallback font for LuaLaTeX so that CJK characters in author
+% names (and other text) render instead of being silently dropped. The fallback
+% must be declared before fontsetup loads the New CM fonts so that every font
+% defined by fontsetup inherits it via \defaultfontfeatures+.
+\ifLuaTeX
+  \directlua{
+    luaotfload.add_fallback("cjk_fallback", {
+      "Noto Sans CJK SC:mode=harf;",
+    })
+  }
+  \defaultfontfeatures+{RawFeature={fallback=cjk_fallback}}
+\fi
 \usepackage{fontsetup} % Lazy way to get proper Greek lowercase glyphs
 
 % Use Hack https://sourcefoundry.org/hack/

--- a/test/expected-pub/paper.tex
+++ b/test/expected-pub/paper.tex
@@ -339,6 +339,18 @@ publishing pipeline. \emph{Journal of Open Source Software},
 }{}
 
 %% Font settings
+% Register a CJK fallback font for LuaLaTeX so that CJK characters in author
+% names (and other text) render instead of being silently dropped. The fallback
+% must be declared before fontsetup loads the New CM fonts so that every font
+% defined by fontsetup inherits it via \defaultfontfeatures+.
+\ifLuaTeX
+  \directlua{
+    luaotfload.add_fallback("cjk_fallback", {
+      "Noto Sans CJK SC:mode=harf;",
+    })
+  }
+  \defaultfontfeatures+{RawFeature={fallback=cjk_fallback}}
+\fi
 \usepackage{fontsetup} % Lazy way to get proper Greek lowercase glyphs
 
 % Use Hack https://sourcefoundry.org/hack/


### PR DESCRIPTION
## Summary

- Installs `font-noto-cjk` in the Docker image so Noto Sans CJK SC is available to LuaLaTeX.
- Registers a `cjk_fallback` font chain via `luaotfload.add_fallback` in `default.latex` and applies it with `\defaultfontfeatures+` before `fontsetup` loads the New Computer Modern fonts, so every font fontsetup defines inherits the fallback.
- Updates snapshot test files to match the new template output.

Fixes #121 (CJK characters in author names silently dropped in compiled PDF).

## Test plan

- [ ] Build the Docker image and compile a paper with a CJK author name (e.g. `name: Bingjie (王冰洁) Wang`) — characters should render instead of appearing as blank space.
- [ ] Confirm no `Missing character` warnings for CJK glyphs in the LuaLaTeX log.
- [ ] Run existing snapshot tests (`make test` or equivalent) — they should pass with the updated expected files.